### PR TITLE
トランザクションを用いてtag, registered_tagの作成機能を追加

### DIFF
--- a/app/controllers/mypage/tags_controller.rb
+++ b/app/controllers/mypage/tags_controller.rb
@@ -5,7 +5,7 @@ class Mypage::TagsController < Mypage::BaseController
 
   def create
     @tag = Tag.find_or_initialize_by(tag_params)
-    if create_registered_tag(@tag)
+    if current_user.create_registered_tag(@tag)
       redirect_to mypage_path, notice: "#{@tag.name}を登録しました"
     else
       flash.now[:alert] = '登録できませんでした'
@@ -15,20 +15,20 @@ class Mypage::TagsController < Mypage::BaseController
 
   private
 
-  def create_registered_tag(tag)
-    ActiveRecord::Base.transaction do
-      tag.save!
-      registered_tag = current_user.registered_tags.build(tag_id: tag.id)
-      registered_tag.save!
-    rescue ActiveRecord::RecordInvalid
-      if registered_tag&.invalid?
-        tag.errors.messages.merge!(registered_tag.errors.messages)
-      end
-      false
-    rescue StandardError
-      render status: 500
-    end
-  end
+  # def create_registered_tag(tag)
+  #   ActiveRecord::Base.transaction do
+  #     tag.save!
+  #     registered_tag = current_user.registered_tags.build(tag_id: tag.id)
+  #     registered_tag.save!
+  #   rescue ActiveRecord::RecordInvalid
+  #     if registered_tag&.invalid?
+  #       tag.errors.messages.merge!(registered_tag.errors.messages)
+  #     end
+  #     false
+  #   rescue StandardError
+  #     render status: 500
+  #   end
+  # end
 
   def tag_params
     params.require(:tag).permit(:name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,19 @@ class User < ApplicationRecord
       break random_token unless self.class.exists?(uuid: random_token)
     end
   end
+
+  def create_registered_tag(tag)
+    ActiveRecord::Base.transaction do
+      tag.save!
+      registered_tag = registered_tags.build(tag_id: tag.id)
+      registered_tag.save!
+    rescue ActiveRecord::RecordInvalid
+      if registered_tag&.invalid?
+        tag.errors.messages.merge!(registered_tag.errors.messages)
+      end
+      false
+    rescue StandardError
+      render status: 500
+    end
+  end
 end


### PR DESCRIPTION
## 概要
close #51

リファクタリング
- トランザクションを用いて、Userモデルでcreate_registered_tagメソッドを定義
- バリデーションエラーメッセージについては c6d8595 で対応済