### PR TITLE
ユーザーが登録できるハッシュタグの数を制限

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,9 @@ gem 'webpacker'
 gem 'enum_help'
 gem 'rails-i18n'
 # 機能
-gem 'pagy', '~> 3.5'
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'config'
+gem 'pagy', '~> 3.5'
 gem 'sorcery', '>= 0.15.0'
 # 定期実行
 gem 'redis-namespace'

--- a/app/javascript/plugins/vee-validate.js
+++ b/app/javascript/plugins/vee-validate.js
@@ -13,7 +13,7 @@ extend("max", {
 const filter = remindDay => {
   const stringRemindDay = String(remindDay)
   if (stringRemindDay === null) {
-    return 0
+    return null
   }
   const deleteDayResult = stringRemindDay.split("日").join("")
   const result = deleteDayResult.replace(/[０-９]/g, s =>

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -6,8 +6,7 @@ class RegisteredTag < ApplicationRecord
   belongs_to :tag
 
   validates :privacy, presence: true
-  validates :remind_day, presence: true,
-                         numericality: { only_integer: true, less_than_or_equal_to: 30 }
+  validates :remind_day, numericality: { only_integer: true, less_than_or_equal_to: 30 }
   validates :tag_id, uniqueness: { scope: :user_id, message: 'は既に登録しています' }
   validate :user_registered_tags_count_validate
 
@@ -77,7 +76,7 @@ class RegisteredTag < ApplicationRecord
   private
 
   def filter_remind_day
-    self.remind_day = remind_day
+    self.remind_day = 0 if remind_day.nil?
   end
 
   def user_registered_tags_count_validate

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -9,6 +9,7 @@ class RegisteredTag < ApplicationRecord
   validates :remind_day, presence: true,
                          numericality: { only_integer: true, less_than_or_equal_to: 30 }
   validates :tag_id, uniqueness: { scope: :user_id, message: 'は既に登録しています' }
+  validate :user_registered_tags_size_validate
 
   enum privacy: { published: 0, closed: 1, limited: 2 }
 
@@ -77,5 +78,9 @@ class RegisteredTag < ApplicationRecord
 
   def filter_remind_day
     self.remind_day = remind_day
+  end
+
+  def user_registered_tags_size_validate
+    errors.add(:base, '登録できるハッシュタグは3つまでです') if user.registered_tags.size > 3
   end
 end

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -37,7 +37,8 @@ class RegisteredTag < ApplicationRecord
   def tweet_rate
     return 0 if day_from_first_tweet.zero?
 
-    denominator = day_from_last_tweet.zero? ? day_from_first_tweet : day_from_first_tweet - 1 # 昨日時点までのデータで計算する
+    # 今日のデータがない場合は昨日時点までのデータで計算する
+    denominator = day_from_last_tweet.zero? ? day_from_first_tweet : day_from_first_tweet - 1
     tweeted_day_count * 100 / denominator
   end
 

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -81,6 +81,6 @@ class RegisteredTag < ApplicationRecord
   end
 
   def user_registered_tags_size_validate
-    errors.add(:base, '登録できるハッシュタグは3つまでです') if user.registered_tags.size > 3
+    errors.add(:base, '登録できるハッシュタグは3つまでです') if user&.registered_tags&.size.to_d > 3
   end
 end

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -9,7 +9,7 @@ class RegisteredTag < ApplicationRecord
   validates :remind_day, presence: true,
                          numericality: { only_integer: true, less_than_or_equal_to: 30 }
   validates :tag_id, uniqueness: { scope: :user_id, message: 'は既に登録しています' }
-  validate :user_registered_tags_size_validate
+  validate :user_registered_tags_count_validate
 
   enum privacy: { published: 0, closed: 1, limited: 2 }
 
@@ -80,7 +80,7 @@ class RegisteredTag < ApplicationRecord
     self.remind_day = remind_day
   end
 
-  def user_registered_tags_size_validate
-    errors.add(:base, '登録できるハッシュタグは3つまでです') if user&.registered_tags&.size.to_d > 3
+  def user_registered_tags_count_validate
+    errors.add(:base, '登録できるハッシュタグは3つまでです') if user&.registered_tags&.count.to_d >= 3
   end
 end

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -15,11 +15,7 @@ class RegisteredTag < ApplicationRecord
   scope :asc, -> { order(created_at: :asc) }
 
   def self.by_user(user_uuid)
-    if user_uuid
-      includes(:user).where(users: { uuid: user_uuid })
-    else
-      all
-    end
+    user_uuid ? includes(:user).where(users: { uuid: user_uuid }) : all
   end
 
   def last_tweeted_at
@@ -41,11 +37,7 @@ class RegisteredTag < ApplicationRecord
   def tweet_rate
     return 0 if day_from_first_tweet.zero?
 
-    denominator = if day_from_last_tweet.zero? # 当日のツイートが存在する場合
-                    day_from_first_tweet
-                  else
-                    day_from_first_tweet - 1 # 昨日時点までのデータで計算する
-                  end
+    denominator = day_from_last_tweet.zero? ? day_from_first_tweet : day_from_first_tweet - 1 # 昨日時点までのデータで計算する
     tweeted_day_count * 100 / denominator
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,6 @@ class User < ApplicationRecord
   validates :description, length: { maximum: 300 }
   validates :privacy, presence: true
   validates :role, presence: true
-  # validates :registered_tags, length: { maximum: 3, message: 'は最大3つまでしか登録できません' }
 
   enum privacy: { published: 0, closed: 1 }
   enum role: { admin: 0, general: 1, guest: 2 }
@@ -28,10 +27,12 @@ class User < ApplicationRecord
     end
   end
 
+  # TODO: サービスクラスにしたい
   def register_tag(tag)
     ActiveRecord::Base.transaction do
       tag.save!
-      registered_tag = registered_tags.create!(tag_id: tag.id)
+      registered_tag = registered_tags.build(tag_id: tag.id)
+      registered_tag.save!
       registered_tag.create_tweets!
       registered_tag.fetch_tweets_data!
       true

--- a/app/services/twitter_api.rb
+++ b/app/services/twitter_api.rb
@@ -22,7 +22,7 @@ module TwitterAPI
     end
 
     def remind_message(r_tag)
-      day = (r_tag.day_from_last_tweet == 1) ? '丸1日' : "#{r_tag.day_from_last_tweet}日間"
+      day = r_tag.day_from_last_tweet == 1 ? '丸1日' : "#{r_tag.day_from_last_tweet}日間"
       url = "https://hashlog.work/mypage/tags/#{r_tag.id}"
       "@#{r_tag.user.screen_name}\n##{r_tag.tag.name} のツイートが#{day}途絶えているようです。調子はいかがですか？
 \n通知を解除する場合は以下のリンクから設定してください。\n#{url}"

--- a/app/services/twitter_api.rb
+++ b/app/services/twitter_api.rb
@@ -22,12 +22,7 @@ module TwitterAPI
     end
 
     def remind_message(r_tag)
-      day = case r_tag.day_from_last_tweet
-            when 1
-              '丸1日'
-            else
-              "#{r_tag.day_from_last_tweet}日間"
-            end
+      day = (r_tag.day_from_last_tweet == 1) ? '丸1日' : "#{r_tag.day_from_last_tweet}日間"
       url = "https://hashlog.work/mypage/tags/#{r_tag.id}"
       "@#{r_tag.user.screen_name}\n##{r_tag.tag.name} のツイートが#{day}途絶えているようです。調子はいかがですか？
 \n通知を解除する場合は以下のリンクから設定してください。\n#{url}"

--- a/spec/models/registered_tag_spec.rb
+++ b/spec/models/registered_tag_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe RegisteredTag, type: :model do
                     .scoped_to(:user_id)
                     .with_message('は既に登録しています'))
     end
+    it :user_registered_tags_size_validate do
+      user = create(:user)
+      user.registered_tags.create(tag_id: create(:tag).id)
+      registered_tag = build(:registered_tag, user: user)
+      # binding.pry
+      expect(registered_tag).to be_invalid
+      expect(registered_tag.errors.full_messages).to include '登録できるハッシュタグは3つまでです'
+    end
   end
 
   describe 'default value' do

--- a/spec/models/registered_tag_spec.rb
+++ b/spec/models/registered_tag_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe RegisteredTag, type: :model do
   describe 'validations' do
     before { create(:registered_tag) }
     it { is_expected.to validate_presence_of(:privacy) }
-    it { is_expected.to validate_presence_of(:remind_day) }
+    it do
+      is_expected.to validate_numericality_of(:remind_day).only_integer.is_less_than_or_equal_to(30)
+    end
     it do
       is_expected.to(validate_uniqueness_of(:tag_id)
                     .scoped_to(:user_id)

--- a/spec/models/registered_tag_spec.rb
+++ b/spec/models/registered_tag_spec.rb
@@ -14,11 +14,10 @@ RSpec.describe RegisteredTag, type: :model do
                     .scoped_to(:user_id)
                     .with_message('は既に登録しています'))
     end
-    it :user_registered_tags_size_validate do
+    it :user_registered_tags_count_validate do
       user = create(:user)
-      user.registered_tags.create(tag_id: create(:tag).id)
+      create_list(:registered_tag, 3, user: user)
       registered_tag = build(:registered_tag, user: user)
-      # binding.pry
       expect(registered_tag).to be_invalid
       expect(registered_tag.errors.full_messages).to include '登録できるハッシュタグは3つまでです'
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe User, type: :model do
             let(:tag) { create(:tag) }
             it '"登録できるハッシュタグは3つまでです"を含む' do
               create_list(:registered_tag, 3, user: user)
-              # binding.pry
               user.register_tag(tag)
               expect(tag.errors.full_messages).to include '登録できるハッシュタグは3つまでです'
             end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,6 +68,32 @@ RSpec.describe User, type: :model do
         it 'user.registered_tagが作成されない' do
           expect { user.register_tag(invalid_tag) }.not_to change(RegisteredTag, :count)
         end
+        describe 'tag.errors.full_messagesの値' do
+          context 'tag.name = ""のとき' do
+            let(:tag) { build(:tag, name: '') }
+            it '"名前を入力してください"を含む' do
+              user.register_tag(tag)
+              expect(tag.errors.full_messages).to include '名前を入力してください'
+            end
+          end
+          context 'registered_tagが重複しているとき' do
+            let(:tag) { build(:tag, name: '重複する名前') }
+            it '"ハッシュタグは既に登録しています"を含む' do
+              create(:registered_tag, user: user, tag: tag)
+              user.register_tag(tag)
+              expect(tag.errors.full_messages).to include 'ハッシュタグは既に登録しています'
+            end
+          end
+          context '同一ユーザーのregistered_tagとして4つ目のとき' do
+            let(:tag) { create(:tag) }
+            it '"登録できるハッシュタグは3つまでです"を含む' do
+              create_list(:registered_tag, 3, user: user)
+              # binding.pry
+              user.register_tag(tag)
+              expect(tag.errors.full_messages).to include '登録できるハッシュタグは3つまでです'
+            end
+          end
+        end
       end
     end
 

--- a/spec/requests/api/v1/registered_tags_spec.rb
+++ b/spec/requests/api/v1/registered_tags_spec.rb
@@ -1,8 +1,5 @@
 RSpec.describe 'RegisteredTags', type: :request do
   describe 'GET /api/v1/registered_tags' do
-    # latest_registered_tagの場所がおかしいのは、作成順に並べるため
-    # 実際は作成日が前後することはない
-    # https://ddnexus.github.io/pagy/extras/array.html
     let(:oldest_registered_tag) { RegisteredTag.asc.first }
     let(:latest_registered_tag) { RegisteredTag.asc.last }
     let(:registered_tags) { RegisteredTag.asc }
@@ -49,7 +46,7 @@ RSpec.describe 'RegisteredTags', type: :request do
     end
   end
   describe 'GET /api/v1/users/:user_uuid/registered_tags' do
-    let(:user) { create(:user, :with_tags) }
+    let(:user) { create(:user) }
     let!(:latest_registered_tag) { create(:registered_tag, user: user, created_at: Date.tomorrow) }
     let!(:oldest_registered_tag) { create(:registered_tag, :created_yesterday, user: user) }
     let(:registered_tags) { user.registered_tags.asc }
@@ -63,7 +60,7 @@ RSpec.describe 'RegisteredTags', type: :request do
       expect(response.status).to eq 200
     end
     it 'User.find(params[:uuid]).registered_tags.ascのJSONを返す' do
-      expect(tags_json.length).to eq 5
+      expect(tags_json.length).to eq 2
       tags_json.zip(registered_tags).each do |tag_json, registered_tag|
         expect(tag_json).to eq({
           'id' => registered_tag.id,

--- a/spec/requests/api/v1/registered_tags_spec.rb
+++ b/spec/requests/api/v1/registered_tags_spec.rb
@@ -207,12 +207,29 @@ RSpec.describe 'RegisteredTags', type: :request do
       end
       context 'remind_dayが"aaa"（ただの文字列）のとき' do
         let(:remind_day) { 'aaa' }
-        it 'remind_dayは0として保存される' do
+        it '422 UnprocessableEntityを返す' do
           patch "/api/v1/registered_tags/#{registered_tag.id}", params: {
             tag: { privacy: '非公開', remindDay: remind_day }
           }
-          updated_registered_tag = registered_tag.reload
-          expect(updated_registered_tag.remind_day).to eq 0
+          expect(response.status).to eq 422
+        end
+        it 'エラーメッセージのJSONを返す' do
+          patch "/api/v1/registered_tags/#{registered_tag.id}", params: {
+            tag: { privacy: '非公開', remindDay: remind_day }
+          }
+          expect(json['error']).to eq({
+            'status' => '422',
+            'title' => '登録内容が適切ではありません',
+            'detail' => '登録内容を確認してください',
+            'messages' => ['リマインダー日数は数値で入力してください']
+          })
+        end
+        it 'registered_tag.remind_dayを変更しない' do
+          expect do
+            patch "/api/v1/registered_tags/#{registered_tag.id}", params: {
+              tag: { privacy: '非公開', remindDay: remind_day }
+            }
+          end.not_to change(registered_tag, :remind_day)
         end
       end
       context 'remind_dayが31のとき' do


### PR DESCRIPTION
## 概要
close #72
- userが持てるregistered_tagの数を3つまでに制限
  - モデルのバリデーションのスペックを追加
- register_tagメソッドのバリデーションエラーメッセージに関するスペックを追加
- remind_dayの修正
  - バリデーションの`presence: true`と`:numericality`が重複しているので前者を削除
  - nilのとき0として保存する