### PR TITLE
404エラーページを追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,7 @@
 class StaticPagesController < ApplicationController
   def top; end
 
-  def privacy; end
-
-  def terms; end
+  def routing_error
+    render :top, status: 404
+  end
 end

--- a/app/javascript/packs/router.js
+++ b/app/javascript/packs/router.js
@@ -6,6 +6,7 @@ import Mypage from "../pages/Mypage"
 import MyTag from "../pages/MyTag"
 import User from "../pages/User"
 import UserTag from "../pages/UserTag"
+import NotFound from "../pages/NotFound"
 
 const routes = [
   {
@@ -34,7 +35,8 @@ const routes = [
     path: "/users/:userUuid/tags/:tagId",
     name: "userTag",
     component: UserTag
-  }
+  },
+  { path: "*", name: "notFound", component: NotFound }
 ]
 
 const router = new VueRouter({ mode: "history", routes })

--- a/app/javascript/pages/NotFound.vue
+++ b/app/javascript/pages/NotFound.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="content pt-10 pb-5">
+    <h1 class="display-3 font-weight-thin">404 NotFound</h1>
+    <div class="mt-10 mb-10">
+      <p>お探しのページが見つかりませんでした。</p>
+      <p>
+        一時的にアクセスができない状況にあるか
+        <br class="d-none d-sm-flex" />移動もしくは削除された可能性があります。
+      </p>
+      <p>URLにお間違いがないか再度ご確認ください。</p>
+    </div>
+    <v-btn color="primary" depressed :to="{ name: 'top' }">
+      <v-icon left>mdi-exit-run</v-icon>トップページに戻る
+    </v-btn>
+  </div>
+</template>
+
+<script>
+export default {
+  title: "404 NotFound",
+  mounted() {
+    this.$store.dispatch("page/setType", "normal")
+  }
+}
+</script>
+
+<style scoped>
+.content {
+  margin: 0 auto;
+  max-width: 400px;
+}
+</style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,6 @@ Rails.application.routes.draw do
   require 'sidekiq/web'
   mount Sidekiq::Web, at: '/sidekiq'
 
-  # ルーティングエラーを拾う 404を返すだけなので、必要があるかは要検討
-  # get '*not_found', to: 'api/v1/base#routing_error'
-  # post '*not_found', to: 'api/v1/base#routing_error'
+  # ルーティングエラーを拾う（getのみ）
+  get '*path', to: 'static_pages#routing_error'
 end


### PR DESCRIPTION
## 概要
close #36

<img width="1440" alt="スクリーンショット 2020-05-31 13 34 13" src="https://user-images.githubusercontent.com/44717752/83344569-7b00ae80-a343-11ea-9898-9784122830af.png">

- Rails側
  - ルーティングで設定されたgetリクエスト以外は`static_pages#routing_error`アクションに飛ぶようにする
  - 404ステータスを返して`static_pages/top`を表示する
- Vue側
  - routerで設定されたルーティング以外では`NotFound`コンポーネントを表示する
  - NotFoundコンポーネントの作成

## コメント

500エラーページはどうしようと思ったが、そもそもRails側ではAPIしかしていないので、エラーページを出す必要はないのか？
Vue側で500エラーをrescueできるのか、それぞれリクエストをしたときにcatchでエラーハンドリングを行うべきなのか。

## 参考資料

https://blog.nakamu.life/posts/vue-router-404-with-laravel