### PR TITLE
細かいバグ修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
 
   validates :twitter_id, presence: true, uniqueness: true
   validates :screen_name, presence: true
-  validates :name, presence: true, length: { maximum: 30 }
+  validates :name, presence: true, length: { maximum: 50 }
   validates :description, length: { maximum: 300 }
   validates :privacy, presence: true
   validates :role, presence: true

--- a/app/services/twitter_api.rb
+++ b/app/services/twitter_api.rb
@@ -67,7 +67,7 @@ module TwitterAPI
 
     def standard_search
       @standard_search ||= begin
-        client.search("##{tag_name} from:#{user.screen_name}",
+        client.search("##{tag_name} from:#{user.screen_name} exclude:retweets",
                       result_type: 'recent', count: 100).take(100).map do |result|
           tweeted_ats << result.created_at
           tweet_ids << result.id
@@ -80,6 +80,8 @@ module TwitterAPI
         client.premium_search("##{tag_name} from:#{user.screen_name}",
                               { maxResults: 100 },
                               { product: '30day' }).take(100).map do |result|
+          next if result.retweeted_status.present?
+
           tweeted_ats << result.created_at
           tweet_ids << result.id
         end
@@ -88,7 +90,7 @@ module TwitterAPI
 
     def everyday_search
       @everyday_search ||= begin
-        client.search("##{tag_name} from:#{user.screen_name}",
+        client.search("##{tag_name} from:#{user.screen_name} exclude:retweets",
                       result_type: 'recent', since_id: since_id).take(100).map do |result|
           tweeted_ats << result.created_at
           tweet_ids << result.id

--- a/app/services/twitter_api.rb
+++ b/app/services/twitter_api.rb
@@ -35,7 +35,6 @@ module TwitterAPI
     def initialize(user, tag_name, since_id = nil)
       @tweet_ids = []
       @tweeted_ats = []
-      @tweet_oembeds = []
       @user = user
       @tag_name = tag_name
       @since_id = since_id
@@ -56,19 +55,18 @@ module TwitterAPI
             .take(100)
             .map do |oembed|
         oembed.html =~ %r{\" dir=\"ltr\">(.+)</p>}
-        tweet_oembeds << $+
-      end
-      tweet_oembeds.zip(tweeted_ats, tweet_ids)
+        $+
+      end.zip(tweeted_ats, tweet_ids)
     end
 
     private
 
-    attr_reader :user, :tag_name, :since_id, :tweet_ids, :tweeted_ats, :tweet_oembeds
+    attr_reader :user, :tag_name, :since_id, :tweet_ids, :tweeted_ats
 
     def standard_search
       @standard_search ||= begin
         client.search("##{tag_name} from:#{user.screen_name} exclude:retweets",
-                      result_type: 'recent', count: 100).take(100).map do |result|
+                      result_type: 'recent', count: 100).take(100).each do |result|
           tweeted_ats << result.created_at
           tweet_ids << result.id
         end
@@ -79,7 +77,7 @@ module TwitterAPI
       @premium_search ||= begin
         client.premium_search("##{tag_name} from:#{user.screen_name}",
                               { maxResults: 100 },
-                              { product: '30day' }).take(100).map do |result|
+                              { product: '30day' }).take(100).each do |result|
           next if result.retweeted_status.present?
 
           tweeted_ats << result.created_at
@@ -91,7 +89,7 @@ module TwitterAPI
     def everyday_search
       @everyday_search ||= begin
         client.search("##{tag_name} from:#{user.screen_name} exclude:retweets",
-                      result_type: 'recent', since_id: since_id).take(100).map do |result|
+                      result_type: 'recent', since_id: since_id).take(100).each do |result|
           tweeted_ats << result.created_at
           tweet_ids << result.id
         end

--- a/app/services/twitter_api_client.rb
+++ b/app/services/twitter_api_client.rb
@@ -10,7 +10,7 @@ module TwitterAPIClient
         config.access_token_secret = Rails.application.credentials.twitter[:access_token_secret]
         # config.access_token        = @user.access_token || Rails.application.credentials.twitter[:access_token]
         # config.access_token_secret = @user.access_token_secret || Rails.application.credentials.twitter[:access_token_secret]
-        config.dev_environment     = 'dev'
+        config.dev_environment     = 'premium'
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_uniqueness_of(:twitter_id).case_insensitive }
     it { is_expected.to validate_presence_of(:screen_name) }
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_length_of(:name).is_at_most(30) }
+    it { is_expected.to validate_length_of(:name).is_at_most(50) }
     it { is_expected.to validate_length_of(:description).is_at_most(300) }
   end
 

--- a/spec/vcr_cassettes/twitter_api/everyday_search.yml
+++ b/spec/vcr_cassettes/twitter_api/everyday_search.yml
@@ -4,7 +4,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97%20from:aiandrox&result_type=recent&since_id=1255854602626330624
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97%20from:aiandrox%20exclude:retweets&result_type=recent&since_id=1255854602626330624
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/everyday_search/全てのタグのツイートを取得.yml
+++ b/spec/vcr_cassettes/twitter_api/everyday_search/全てのタグのツイートを取得.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23tag_1%20from:user_1&result_type=recent
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23tag_1%20from:user_1%20exclude:retweets&result_type=recent
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/everyday_search/前日のツイートがなかったとき.yml
+++ b/spec/vcr_cassettes/twitter_api/everyday_search/前日のツイートがなかったとき.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97%20from:aiandrox&result_type=recent&since_id=1255854602626330624
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97%20from:aiandrox%20exclude:retweets&result_type=recent&since_id=1255854602626330624
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/everyday_search/正常系_前日のツイートを取得したとき.yml
+++ b/spec/vcr_cassettes/twitter_api/everyday_search/正常系_前日のツイートを取得したとき.yml
@@ -4,7 +4,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97%20from:aiandrox&result_type=recent&since_id=1255854602626330624
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97%20from:aiandrox%20exclude:retweets&result_type=recent&since_id=1255854602626330624
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/everyday_search/該当のツイートがない場合.yml
+++ b/spec/vcr_cassettes/twitter_api/everyday_search/該当のツイートがない場合.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23absent_tag%20from:aiandrox&result_type=recent&since_id=1255854602626330624
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23absent_tag%20from:aiandrox%20exclude:retweets&result_type=recent&since_id=1255854602626330624
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/everyday_search_all_tweets.yml
+++ b/spec/vcr_cassettes/twitter_api/everyday_search_all_tweets.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23tag_1%20from:user_1&result_type=recent
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23tag_1%20from:user_1%20exclude:retweets&result_type=recent
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/everyday_search_none.yml
+++ b/spec/vcr_cassettes/twitter_api/everyday_search_none.yml
@@ -4,7 +4,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97%20from:aiandrox&result_type=recent&since_id=1255854602626330624
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97%20from:aiandrox%20exclude:retweets&result_type=recent&since_id=1255854602626330624
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/everyday_search_test.yml
+++ b/spec/vcr_cassettes/twitter_api/everyday_search_test.yml
@@ -4,7 +4,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%86%E3%82%B9%E3%83%88%20from:aiandrox&result_type=recent&since_id=1255013230675546112
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%86%E3%82%B9%E3%83%88%20from:aiandrox%20exclude:retweets&result_type=recent&since_id=1255013230675546112
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/premium_search.yml
+++ b/spec/vcr_cassettes/twitter_api/premium_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.twitter.com/1.1/tweets/search/30day/dev.json
+    uri: https://api.twitter.com/1.1/tweets/search/30day/premium.json
     body:
       encoding: UTF-8
       string: '{"maxResults":100,"query":"#ポートフォリオ進捗 from:aiandrox"}'
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - TwitterRubyGem/7.0.0
       Authorization:
-      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="7fbd1b9719261380bf293810d13b60a9",
-        oauth_signature="IS%2B17N5sVkeRlqD5%2FhunopwBynQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588401954", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="f7175a18a948ba207f843fd89b682b24",
+        oauth_signature="w4MurdEMcgnRnqu%2Fz%2BEuLakp7jw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
       Connection:
       - close
       Content-Type:
@@ -27,50 +27,103 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '10982'
+      - '44718'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 02 May 2020 06:45:55 GMT
+      - Mon, 01 Jun 2020 11:17:05 GMT
       Server:
       - tsa_m
       Set-Cookie:
-      - guest_id=v1%3A158840195494721963; Max-Age=63072000; Expires=Mon, 2 May 2022
-        06:45:55 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
-      - personalization_id="v1_rU+/EdUCgu1+j4XcpUlFiA=="; Max-Age=63072000; Expires=Mon,
-        2 May 2022 06:45:55 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id=v1%3A159101022540251868; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:05 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_5XHOT46XkmrdeElKuvbLqg=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:05 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=631138519
       X-Connection-Hash:
-      - b7e72ee1921020bf8a60667fe9211453
+      - 833c9e46ac3520b7ca6456b0d6630fab
       X-Response-Time:
-      - '176'
+      - '204'
       X-Tsa-Request-Body-Time:
-      - '0'
+      - '1'
     body:
       encoding: UTF-8
-      string: '{"results":[{"created_at":"Fri May 01 15:56:11 +0000 2020","id":1256251076820389894,"id_str":"1256251076820389894","text":"\u66f8\u3044\u305f\u3002\u30ea\u30d5\u30a1\u30af\u30bf\u30ea\u30f3\u30b0\u306b\u3088\u308a\u3001180\u884c\u304b\u3089160\u884c\u306b\u306a\u308a\u307e\u3057\u305f\u3002\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
+      string: '{"results":[{"created_at":"Mon Jun 01 10:00:33 +0000 2020","id":1267395602662354946,"id_str":"1267395602662354946","text":"\u76f4\u308a\u307e\u3057\u305f\u3002\u30e2\u30c3\u30af\u304c\u58ca\u308c\u307e\u3057\u305f\u3002\u304b\u306a\u3057\u3044\u3067\u3059\u3002\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
         href=\"http:\/\/twitter.com\/download\/android\" rel=\"nofollow\"\u003eTwitter
-        for Android\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":1256130675939217408,"in_reply_to_status_id_str":"1256130675939217408","in_reply_to_user_id":1048451188209770497,"in_reply_to_user_id_str":"1048451188209770497","in_reply_to_screen_name":"aiandrox","user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u2192\u5c71\u68a8\u2192\u6771\u4eac","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u76ee\u6307\u3057\u3066Rails\u3068\u304b\u9811\u5f35\u3063\u3066\u308b\u4eba\u3067\u3059\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
-        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":115,"friends_count":122,"listed_count":3,"favourites_count":270,"statuses_count":852,"created_at":"Sat
-        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":0,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[34,44]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Thu
-        Apr 30 13:40:44 +0000 2020","id":1255854602626330624,"id_str":"1255854602626330624","text":"\u30ac\u30d0\u30ac\u30d0\u30ed\u30b8\u30c3\u30af\u304c\u5224\u660e\u3057\u307e\u3057\u305f\u2026\u2026\u52d5\u304b\u306a\u3044\u30e1\u30bd\u30c3\u30c9\u4f5c\u3063\u3066\u307e\u3057\u305f\u2026\u2026\u30c6\u30b9\u30c8\u3063\u3066\u5927\u4e8b\u3067\u3059\u306d\u2026\u2026\u3002\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
-        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u2192\u5c71\u68a8\u2192\u6771\u4eac","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u76ee\u6307\u3057\u3066Rails\u3068\u304b\u9811\u5f35\u3063\u3066\u308b\u4eba\u3067\u3059\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
-        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":115,"friends_count":122,"listed_count":3,"favourites_count":270,"statuses_count":852,"created_at":"Sat
-        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":1,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[47,57]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Thu
-        Apr 30 10:31:08 +0000 2020","id":1255806887917830144,"id_str":"1255806887917830144","text":"\u30fbActiveJob\u5b8c\u5168\u306b\u7406\u89e3\u3057\u305f\u3002\n\u30fbasync\u3001await\u306b\u3064\u3044\u3066\u771f\u9762\u76ee\u306b\u5b66\u3070\u306a\u3051\u308c\u3070\u306a\u3089\u306a\u3044\u65e5\u304c\u6765\u3066\u3057\u307e\u3063\u305f\u3002\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
-        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u2192\u5c71\u68a8\u2192\u6771\u4eac","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u76ee\u6307\u3057\u3066Rails\u3068\u304b\u9811\u5f35\u3063\u3066\u308b\u4eba\u3067\u3059\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
-        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":115,"friends_count":122,"listed_count":3,"favourites_count":270,"statuses_count":852,"created_at":"Sat
-        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":1,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[59,69]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Wed
-        Apr 29 03:47:53 +0000 2020","id":1255343018363756544,"id_str":"1255343018363756544","text":"\u81ea\u5206\u304c\u4f7f\u7528\u8005\u306b\u306a\u3089\u3093\u3068\u3044\u3051\u306a\u3044\u306e\u3067\u3001\u3068\u308a\u3042\u3048\u305a\u4e00\u65e5\u4e00\u56de\u306f\u545f\u304d\u307e\u3059\u3002\n\u30c4\u30a4\u30fc\u30c8\u81ea\u52d5\u53ce\u96c6\u306f\u3067\u304d\u305f\u3051\u3069\u3001status:401\u306e\u3068\u304d\u306ejson\u304c\u53d6\u5f97\u3067\u304d\u307e\u305b\u3093\u3002\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
-        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u2192\u5c71\u68a8\u2192\u6771\u4eac","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u76ee\u6307\u3057\u3066Rails\u3068\u304b\u9811\u5f35\u3063\u3066\u308b\u4eba\u3067\u3059\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
-        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":115,"friends_count":122,"listed_count":3,"favourites_count":270,"statuses_count":852,"created_at":"Sat
-        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":1,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[77,87]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]}],"requestParameters":{"maxResults":100,"fromDate":"202004020000","toDate":"202005020645"}}'
-    http_version: null
-  recorded_at: Sat, 02 May 2020 06:45:55 GMT
+        for Android\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":1267360976967397377,"in_reply_to_status_id_str":"1267360976967397377","in_reply_to_user_id":1048451188209770497,"in_reply_to_user_id_str":"1048451188209770497","in_reply_to_screen_name":"aiandrox","user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":0,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[24,34]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Mon
+        Jun 01 07:42:57 +0000 2020","id":1267360976967397377,"id_str":"1267360976967397377","text":"\u81f4\u547d\u7684\u306a\u6b20\u9665\u3092\u898b\u3064\u3051\u3066\u3057\u307e\u3063\u305f\u3068\u3060\u3051\u2026\u2026\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
+        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":1,"retweet_count":0,"favorite_count":1,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[21,31]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Sun
+        May 31 06:55:24 +0000 2020","id":1266986618834968579,"id_str":"1266986618834968579","text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u52e2\u8ab0\u3082\u8a00\u3063\u3066\u306a\u304b\u3063\u305f\u3093\u3060\u3051\u3069\u3001\u5229\u7528\u898f\u7d04\u66f8\u304f\u306e\u3057\u3093\u3069\u304f\u306a\u3044\u3067\u3059\u304b\u2026\u2026\uff1f\n\u6291\u3048\u308b\u30dd\u30a4\u30f3\u30c8\u304c\u3055\u3063\u3071\u3069\u308f\u304b\u3089\u3093\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
+        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":0,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[59,69]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Fri
+        May 29 09:36:33 +0000 2020","id":1266302400849047552,"id_str":"1266302400849047552","text":"Q.
+        \u5b9f\u88c5\u3092\u9032\u3081\u3066\u3044\u304f\u306b\u5f93\u3063\u3066\u7406\u89e3\u5ea6\u306f\u6df1\u307e\u308b\u306f\u305a\u306a\u306e\u306b\u3001\u5168\u7136\u30b9\u30a4\u30b9\u30a4\u66f8\u3051\u306a\u3044\u306e\u306f\u3069\u3046\u3057\u3066\uff1f\n\nA.
+        \u904e\u53bb\u306e\u304a\u524d\u304c\u697d\u306a\u3068\u3053\u308d\u3092\u5148\u306b\u5b9f\u88c5\u3057\u3066\u3044\u308b\u304b\u3089\u3084\u3067\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
+        href=\"http:\/\/twitter.com\/download\/android\" rel=\"nofollow\"\u003eTwitter
+        for Android\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":2,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[75,85]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Mon
+        May 18 09:55:28 +0000 2020","id":1262320895525191681,"id_str":"1262320895525191681","text":"\u3074\u3048\u3093\u3002#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357
+        https:\/\/t.co\/TVAgVohdue","display_text_range":[0,14],"source":"\u003ca
+        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":2,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[4,14]}],"urls":[],"user_mentions":[],"symbols":[],"media":[{"id":1262320866307653632,"id_str":"1262320866307653632","indices":[15,38],"media_url":"http:\/\/pbs.twimg.com\/media\/EYSqI8zUwAAngKG.png","media_url_https":"https:\/\/pbs.twimg.com\/media\/EYSqI8zUwAAngKG.png","url":"https:\/\/t.co\/TVAgVohdue","display_url":"pic.twitter.com\/TVAgVohdue","expanded_url":"https:\/\/twitter.com\/aiandrox\/status\/1262320895525191681\/photo\/1","type":"photo","sizes":{"large":{"w":898,"h":176,"resize":"fit"},"small":{"w":680,"h":133,"resize":"fit"},"medium":{"w":898,"h":176,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"}}}]},"extended_entities":{"media":[{"id":1262320866307653632,"id_str":"1262320866307653632","indices":[15,38],"media_url":"http:\/\/pbs.twimg.com\/media\/EYSqI8zUwAAngKG.png","media_url_https":"https:\/\/pbs.twimg.com\/media\/EYSqI8zUwAAngKG.png","url":"https:\/\/t.co\/TVAgVohdue","display_url":"pic.twitter.com\/TVAgVohdue","expanded_url":"https:\/\/twitter.com\/aiandrox\/status\/1262320895525191681\/photo\/1","type":"photo","sizes":{"large":{"w":898,"h":176,"resize":"fit"},"small":{"w":680,"h":133,"resize":"fit"},"medium":{"w":898,"h":176,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"}}}]},"favorited":false,"retweeted":false,"possibly_sensitive":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Sat
+        May 16 22:08:21 +0000 2020","id":1261780552950022144,"id_str":"1261780552950022144","text":"\u3063\u3066\u3044\u3046\u9032\u6357\u3002\u3060\u304c\u3057\u304b\u30575\u65e5\u3082\u9014\u7d76\u3048\u3066\u306a\u3044\u3093\u3060\u3051\u3069\u2026\u2026\u3002\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357
+        https:\/\/t.co\/lz1GY9kfc3","display_text_range":[0,39],"source":"\u003ca
+        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"quoted_status_id":1261778479332225024,"quoted_status_id_str":"1261778479332225024","quoted_status":{"created_at":"Sat
+        May 16 22:00:06 +0000 2020","id":1261778479332225024,"id_str":"1261778479332225024","text":"@aiandrox\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357
+        \u306e\u30c4\u30a4\u30fc\u30c8\u304c5\u65e5\u9593\u9014\u7d76\u3048\u3066\u3044\u308b\u3088\u3046\u3067\u3059\u3002\u8abf\u5b50\u306f\u3044\u304b\u304c\u3067\u3059\u304b\uff1f","source":"\u003ca
+        href=\"https:\/\/github.com\/Aiandrox\/hashlog\" rel=\"nofollow\"\u003eHashlog_aiandrox\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":1048451188209770497,"in_reply_to_user_id_str":"1048451188209770497","in_reply_to_screen_name":"aiandrox","user":{"id":1242379749650907137,"id_str":"1242379749650907137","name":"Hashlog","screen_name":"Hash1og","location":null,"url":null,"description":"Hashlog\u306e\u30ea\u30de\u30a4\u30f3\u30c0\u30fc\u3092\u304a\u77e5\u3089\u305b\u3059\u308bBOT\u3067\u3059\u3002\u4f55\u304b\u3042\u308a\u307e\u3057\u305f\u3089@aiandrox
+        \u307e\u3067","translator_type":"none","protected":false,"verified":false,"followers_count":1,"friends_count":0,"listed_count":0,"favourites_count":0,"statuses_count":9,"created_at":"Tue
+        Mar 24 09:16:34 +0000 2020","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1267362108703817728\/bSK1Ux-E_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1267362108703817728\/bSK1Ux-E_normal.jpg","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":1,"reply_count":0,"retweet_count":0,"favorite_count":0,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[10,20]}],"urls":[],"user_mentions":[{"screen_name":"aiandrox","name":"END","id":1048451188209770497,"id_str":"1048451188209770497","indices":[0,9]}],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja"},"quoted_status_permalink":{"url":"https:\/\/t.co\/lz1GY9kfc3","expanded":"https:\/\/twitter.com\/Hash1og\/status\/1261778479332225024","display":"twitter.com\/Hash1og\/status\u2026"},"is_quote_status":true,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":0,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[29,39]}],"urls":[{"url":"https:\/\/t.co\/lz1GY9kfc3","expanded_url":"https:\/\/twitter.com\/Hash1og\/status\/1261778479332225024","display_url":"twitter.com\/Hash1og\/status\u2026","indices":[40,63]}],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"possibly_sensitive":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Thu
+        May 14 15:22:55 +0000 2020","id":1260953745988304896,"id_str":"1260953745988304896","text":"\u3044\u308d\u3044\u308d\u3068\u3084\u3070\u3044\u306e\u306f\u308f\u304b\u3063\u3066\u3044\u308b\u3051\u3069\u3001\u3069\u3046\u3059\u308c\u3070\u3044\u3044\u306e\u304b\u308f\u304b\u3089\u306a\u3044\u3002\n\u300c\u3068\u308a\u3042\u3048\u305a\u52d5\u304f\u304b\u3089\u30e8\u30b7\uff01\u300d\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
+        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":1,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[50,60]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Thu
+        May 14 10:53:40 +0000 2020","id":1260885987271438337,"id_str":"1260885987271438337","text":"Vue\u3084\u308a\u305f\u304f\u306a\u3044\u671f\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
+        href=\"http:\/\/twitter.com\/download\/android\" rel=\"nofollow\"\u003eTwitter
+        for Android\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":1,"retweet_count":0,"favorite_count":4,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[11,21]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Tue
+        May 12 01:12:25 +0000 2020","id":1260014937348247552,"id_str":"1260014937348247552","text":"\u300c\u3053\u308c\u306a\u3093\u3067\u3053\u306e\u66f8\u304d\u65b9\u3057\u3066\u306a\u3044\u3093\u3060\uff1f\u300d\u3063\u3066\u601d\u3063\u3066\u76f4\u3057\u305f\u3089\u3046\u307e\u304f\u52d5\u304b\u306a\u304f\u306a\u3063\u3066\u3001\u904e\u53bb\u306e\u81ea\u5206\u306b\u5408\u70b9\u3057\u305f\u3002\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
+        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":3,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[51,61]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Sat
+        May 09 15:39:01 +0000 2020","id":1259145860862013440,"id_str":"1259145860862013440","text":"\u901a\u3089\u306a\u3044\u30b9\u30da\u30c3\u30af\u30921\u3064\u76f4\u3057\u305f\u30893\u3064\u901a\u3089\u306a\u304f\u306a\u3063\u305f\u306e\u3067\u5bdd\u307e\u3059\u3002#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
+        href=\"http:\/\/twitter.com\/download\/android\" rel=\"nofollow\"\u003eTwitter
+        for Android\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":2,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[30,40]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Sat
+        May 09 12:44:03 +0000 2020","id":1259101828609765376,"id_str":"1259101828609765376","text":"\u30c7\u30fc\u30bf\u66f4\u65b0\u304c\u308f\u308a\u3068\u7406\u60f3\u306e\u6319\u52d5\u3057\u3066\u304f\u308c\u3066\u3044\u308b\uff01\n\u305f\u3060\u3001v-model\u3067\u30c6\u30ad\u30b9\u30c8\u30a8\u30ea\u30a2\u3068\u304b\u3068\u30ea\u30f3\u30af\u3057\u3066\u3044\u308b\u304b\u3089\u3001\u30ad\u30e3\u30f3\u30bb\u30eb\u6642\u306b\u623b\u3059\u306e\u306f\u3069\u3046\u3059\u308c\u3070\u3044\u3044\u3093\u3060\uff1f\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
+        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":1,"retweet_count":0,"favorite_count":0,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[76,86]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Fri
+        May 08 16:30:56 +0000 2020","id":1258796536793718784,"id_str":"1258796536793718784","text":"\u30ec\u30b9\u30dd\u30f3\u30b7\u30d6\u5bfe\u5fdc\u3092\u3061\u3083\u3093\u3068\u3057\u305f\u3044\u3068\u8003\u3048\u308b\u3068\u3001Vue\u306b\u3057\u305f\u306e\u306f\u305d\u3093\u306a\u306b\u3088\u304f\u306a\u304b\u3063\u305f\u304b\u3082\u3057\u308c\u306a\u3044\u3002\n\u305d\u3057\u3066\u30da\u30fc\u30b8\u9077\u79fb\u6642\u306b\u30c8\u30e9\u30f3\u30b6\u30af\u30b7\u30e7\u30f3\u304c\u3067\u304d\u306a\u3044\u3002Vuetify\u306b\u6b69\u307f\u5bc4\u3089\u306d\u3070\u2026\u2026\u3002\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","source":"\u003ca
+        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":3,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[90,100]}],"urls":[],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Wed
+        May 06 22:01:22 +0000 2020","id":1258154916956131328,"id_str":"1258154916956131328","text":"\u3053\u3053\u6570\u65e5\u96c6\u4e2d\u529b\u3092\u5b9f\u611f\u3057\u3066\u3044\u306a\u3044\u3002\u30b3\u30fc\u30c9\u304c\u4e0a\u624b\u304f\u52d5\u304b\u306a\u3044\u3053\u3068\u306b\u5bfe\u3057\u3066\u306e\u5fc3\u306e\u6301\u3061\u3088\u3046\u304c\u3042\u307e\u308a\u3088\u304f\u306a\u3044\u3002\n\u304d\u3063\u3068\u3001\u81ea\u5206\u306e\u4e2d\u3067\u4ed5\u69d8\u3092\u6c7a\u3081\u305a\u306b\u5f8c\u56de\u3057\u306b\u3057\u3066\u3044\u305f\u90e8\u5206\u304c\u9855\u5728\u5316\u3057\u3066\u304d\u3066\u3001\u300c\u3053\u308c\u3092\u5b9f\u73fe\u3059\u308b\u305e\uff01\u300d\u3063\u3066\u6c17\u6982\u304c\u5c11\u306a\u304f\u306a\u3063\u305f\u3093\u3060\u3002\n\u4eca\u65e5\u306f\u305d\u2026
+        https:\/\/t.co\/Bp2R5q8wc9","source":"\u003ca href=\"http:\/\/twitter.com\/download\/android\"
+        rel=\"nofollow\"\u003eTwitter for Android\u003c\/a\u003e","truncated":true,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"extended_tweet":{"full_text":"\u3053\u3053\u6570\u65e5\u96c6\u4e2d\u529b\u3092\u5b9f\u611f\u3057\u3066\u3044\u306a\u3044\u3002\u30b3\u30fc\u30c9\u304c\u4e0a\u624b\u304f\u52d5\u304b\u306a\u3044\u3053\u3068\u306b\u5bfe\u3057\u3066\u306e\u5fc3\u306e\u6301\u3061\u3088\u3046\u304c\u3042\u307e\u308a\u3088\u304f\u306a\u3044\u3002\n\u304d\u3063\u3068\u3001\u81ea\u5206\u306e\u4e2d\u3067\u4ed5\u69d8\u3092\u6c7a\u3081\u305a\u306b\u5f8c\u56de\u3057\u306b\u3057\u3066\u3044\u305f\u90e8\u5206\u304c\u9855\u5728\u5316\u3057\u3066\u304d\u3066\u3001\u300c\u3053\u308c\u3092\u5b9f\u73fe\u3059\u308b\u305e\uff01\u300d\u3063\u3066\u6c17\u6982\u304c\u5c11\u306a\u304f\u306a\u3063\u305f\u3093\u3060\u3002\n\u4eca\u65e5\u306f\u305d\u308c\u3092\u8003\u3048\u308b\u3068\u3053\u308d\u304b\u3089\u59cb\u3081\u3088\u3046\u3002\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","display_text_range":[0,141],"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[131,141]}],"urls":[],"user_mentions":[],"symbols":[]}},"quote_count":0,"reply_count":0,"retweet_count":0,"favorite_count":2,"entities":{"hashtags":[],"urls":[{"url":"https:\/\/t.co\/Bp2R5q8wc9","expanded_url":"https:\/\/twitter.com\/i\/web\/status\/1258154916956131328","display_url":"twitter.com\/i\/web\/status\/1\u2026","indices":[117,140]}],"user_mentions":[],"symbols":[]},"favorited":false,"retweeted":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]},{"created_at":"Wed
+        May 06 08:53:12 +0000 2020","id":1257956569985081346,"id_str":"1257956569985081346","text":"\u3093\uff1f^^;\n#\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357
+        https:\/\/t.co\/uauu8lJGln","display_text_range":[0,16],"source":"\u003ca
+        href=\"https:\/\/mobile.twitter.com\" rel=\"nofollow\"\u003eTwitter Web App\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1048451188209770497,"id_str":"1048451188209770497","name":"END","screen_name":"aiandrox","location":"\u5ca1\u5c71\u305a\u3063\u3068\u2192\u5c71\u68a8\u3061\u3087\u3063\u3068\u2192\u6771\u4eac\u30a4\u30de\u30b3\u30b3","url":"https:\/\/lapras.com\/public\/CQMWEEQ","description":"\u5c0f\u5b66\u6821\u306e\u5148\u751f\u304b\u3089\u30a8\u30f3\u30b8\u30cb\u30a2\u306b\u306a\u308a\u305f\u3044\u4eba\u3002\u96d1\u591a\u306b\u545f\u304f\u3002#RUNTEQ
+        1\u6708\u751f\u3002\u8b0e\u89e3\u304d\u597d\u304d\u3002","translator_type":"none","protected":false,"verified":false,"followers_count":131,"friends_count":129,"listed_count":4,"favourites_count":539,"statuses_count":1222,"created_at":"Sat
+        Oct 06 05:53:37 +0000 2018","utc_offset":null,"time_zone":null,"geo_enabled":false,"lang":null,"contributors_enabled":false,"is_translator":false,"profile_background_color":"F5F8FA","profile_background_image_url":"","profile_background_image_url_https":"","profile_background_tile":false,"profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1250601087318413313\/yMmfgkOX_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1048451188209770497\/1585461723","default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"quote_count":0,"reply_count":1,"retweet_count":0,"favorite_count":0,"entities":{"hashtags":[{"text":"\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u9032\u6357","indices":[6,16]}],"urls":[],"user_mentions":[],"symbols":[],"media":[{"id":1257956510354731009,"id_str":"1257956510354731009","indices":[17,40],"media_url":"http:\/\/pbs.twimg.com\/media\/EXUox_6VcAEheCI.png","media_url_https":"https:\/\/pbs.twimg.com\/media\/EXUox_6VcAEheCI.png","url":"https:\/\/t.co\/uauu8lJGln","display_url":"pic.twitter.com\/uauu8lJGln","expanded_url":"https:\/\/twitter.com\/aiandrox\/status\/1257956569985081346\/photo\/1","type":"photo","sizes":{"small":{"w":502,"h":216,"resize":"fit"},"medium":{"w":502,"h":216,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"large":{"w":502,"h":216,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":1257956510354731009,"id_str":"1257956510354731009","indices":[17,40],"media_url":"http:\/\/pbs.twimg.com\/media\/EXUox_6VcAEheCI.png","media_url_https":"https:\/\/pbs.twimg.com\/media\/EXUox_6VcAEheCI.png","url":"https:\/\/t.co\/uauu8lJGln","display_url":"pic.twitter.com\/uauu8lJGln","expanded_url":"https:\/\/twitter.com\/aiandrox\/status\/1257956569985081346\/photo\/1","type":"photo","sizes":{"small":{"w":502,"h":216,"resize":"fit"},"medium":{"w":502,"h":216,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"large":{"w":502,"h":216,"resize":"fit"}}}]},"favorited":false,"retweeted":false,"possibly_sensitive":false,"filter_level":"low","lang":"ja","matching_rules":[{"tag":null}]}],"requestParameters":{"maxResults":100,"fromDate":"202005020000","toDate":"202006011116"}}'
+  recorded_at: Mon, 01 Jun 2020 11:17:05 GMT
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1255854602626330624&lang=ja&omit_script=true
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1260014937348247552&lang=ja&omit_script=true
     body:
       encoding: UTF-8
       string: ''
@@ -78,9 +131,9 @@ http_interactions:
       User-Agent:
       - TwitterRubyGem/7.0.0
       Authorization:
-      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="a4ab7118e46dafa0c274f9749e76124a",
-        oauth_signature="%2FbCetNLl%2FMcjkZYRKueMdRWYmRs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588401955", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="15cf9794ec7fd7cd53d5c647dbe49b57",
+        oauth_signature="6o%2BC9O%2Ffx4VsraH79jaiUWuBMP0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
       Connection:
       - close
       Host:
@@ -97,26 +150,26 @@ http_interactions:
       Content-Disposition:
       - attachment; filename=json.json
       Content-Length:
-      - '942'
+      - '954'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 02 May 2020 06:45:55 GMT
+      - Mon, 01 Jun 2020 11:17:06 GMT
       Expires:
-      - Mon, 08 Apr 2120 06:45:55 GMT
+      - Wed, 08 May 2120 11:17:06 GMT
       Last-Modified:
-      - Sat, 02 May 2020 06:45:55 GMT
+      - Mon, 01 Jun 2020 11:17:06 GMT
       Server:
       - tsa_m
       Set-Cookie:
-      - guest_id=v1%3A158840195550528039; Max-Age=63072000; Expires=Mon, 2 May 2022
-        06:45:55 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
-      - personalization_id="v1_L8UOcbcIyjXgWFvjIU9cMQ=="; Max-Age=63072000; Expires=Mon,
-        2 May 2022 06:45:55 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id=v1%3A159101022603872690; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_UY4g0OHkBRi0BhUDIKuvmg=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=631138519
       X-Connection-Hash:
-      - b49c4fb845fc4fb350a7429b26a65fb7
+      - 95315643526f4851fb78b0fafa0da373
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -124,24 +177,23 @@ http_interactions:
       X-Rate-Limit-Limit:
       - '180'
       X-Rate-Limit-Remaining:
-      - '179'
+      - '166'
       X-Rate-Limit-Reset:
-      - '1588402855'
+      - '1591010535'
       X-Response-Time:
-      - '116'
+      - '120'
       X-Xss-Protection:
       - '0'
     body:
       encoding: UTF-8
-      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1255854602626330624","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
-        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003Eガバガバロジックが判明しました……動かないメソッド作ってました……テストって大事ですね……。\u003Ca
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1260014937348247552","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003E「これなんでこの書き方してないんだ？」って思って直したらうまく動かなくなって、過去の自分に合点した。\u003Ca
         href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
-        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1255854602626330624?ref_src=twsrc%5Etfw\"\u003E2020年4月30日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
-    http_version: null
-  recorded_at: Sat, 02 May 2020 06:45:55 GMT
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1260014937348247552?ref_src=twsrc%5Etfw\"\u003E2020年5月12日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1256251076820389894&lang=ja&omit_script=true
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1260953745988304896&lang=ja&omit_script=true
     body:
       encoding: UTF-8
       string: ''
@@ -149,9 +201,9 @@ http_interactions:
       User-Agent:
       - TwitterRubyGem/7.0.0
       Authorization:
-      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="0209d46b56aee3081c20e5e2f5c431f9",
-        oauth_signature="sDkupXLiSvOjEgQpjFfugSgWChs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588401955", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="2207d9405df6a32e65344d1c9b59b1a2",
+        oauth_signature="fmAqehzZsaGbv3HAiEOkRhKnNpY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
       Connection:
       - close
       Host:
@@ -168,26 +220,26 @@ http_interactions:
       Content-Disposition:
       - attachment; filename=json.json
       Content-Length:
-      - '917'
+      - '962'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 02 May 2020 06:45:55 GMT
+      - Mon, 01 Jun 2020 11:17:06 GMT
       Expires:
-      - Mon, 08 Apr 2120 06:45:55 GMT
+      - Wed, 08 May 2120 11:17:06 GMT
       Last-Modified:
-      - Sat, 02 May 2020 06:45:55 GMT
+      - Mon, 01 Jun 2020 11:17:06 GMT
       Server:
       - tsa_m
       Set-Cookie:
-      - guest_id=v1%3A158840195550542794; Max-Age=63072000; Expires=Mon, 2 May 2022
-        06:45:55 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
-      - personalization_id="v1_hSaepK1XyTpSl9AP1SMJjg=="; Max-Age=63072000; Expires=Mon,
-        2 May 2022 06:45:55 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id=v1%3A159101022605414182; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_C30GwuR5WsTGGGMg9CmcEw=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=631138519
       X-Connection-Hash:
-      - 727b65eb9e1f2505b602b5be665dd285
+      - b54d52eb9ac33cc33be539796d4cc7ec
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -195,24 +247,375 @@ http_interactions:
       X-Rate-Limit-Limit:
       - '180'
       X-Rate-Limit-Remaining:
-      - '178'
+      - '164'
       X-Rate-Limit-Reset:
-      - '1588402855'
+      - '1591010535'
       X-Response-Time:
-      - '116'
+      - '121'
       X-Xss-Protection:
       - '0'
     body:
       encoding: UTF-8
-      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1256251076820389894","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1260953745988304896","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003Eいろいろとやばいのはわかっているけど、どうすればいいのかわからない。\u003Cbr\u003E「とりあえず動くからヨシ！」\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1260953745988304896?ref_src=twsrc%5Etfw\"\u003E2020年5月14日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1259145860862013440&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="2f6c9367af0adf932214cd5d8508fcdc",
+        oauth_signature="Y1lGEyLGHCFHqhG95C1AC9Sh7vo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '889'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Expires:
+      - Wed, 08 May 2120 11:17:06 GMT
+      Last-Modified:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Server:
+      - tsa_m
+      Set-Cookie:
+      - guest_id=v1%3A159101022605403700; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_x+lHOoLx+vbJmMUOLKVi/w=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - ead7941b3dc31c57fee5ea06c0f233e8
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '165'
+      X-Rate-Limit-Reset:
+      - '1591010535'
+      X-Response-Time:
+      - '125'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1259145860862013440","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003E通らないスペックを1つ直したら3つ通らなくなったので寝ます。\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1259145860862013440?ref_src=twsrc%5Etfw\"\u003E2020年5月9日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1257956569985081346&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="6002ae54aacbce18855975f1de57b617",
+        oauth_signature="lMuN36f%2BpEyS%2FxSy0r5Xj%2FdaxnU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '904'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Expires:
+      - Wed, 08 May 2120 11:17:06 GMT
+      Last-Modified:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Server:
+      - tsa_m
+      Set-Cookie:
+      - guest_id=v1%3A159101022606194674; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_isDeIVS5Biw3alG/RwdcVw=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - eb60a7b4529d57c2adb82552dce96334
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '163'
+      X-Rate-Limit-Reset:
+      - '1591010535'
+      X-Response-Time:
+      - '131'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1257956569985081346","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003Eん？^^;\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E
+        \u003Ca href=\"https:\/\/t.co\/uauu8lJGln\"\u003Epic.twitter.com\/uauu8lJGln\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1257956569985081346?ref_src=twsrc%5Etfw\"\u003E2020年5月6日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1258154916956131328&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="b9d99858bdec5a9c84d894f554c8a769",
+        oauth_signature="aPU8l1FhO%2BqKUajZhEoghbpiw5o%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1215'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Expires:
+      - Wed, 08 May 2120 11:17:06 GMT
+      Last-Modified:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Server:
+      - tsa_m
+      Set-Cookie:
+      - guest_id=v1%3A159101022608893785; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_k3s4OqptjZKpHC8APHMh+Q=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 1c06f0009f5023bb7fe1af813e606529
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '162'
+      X-Rate-Limit-Reset:
+      - '1591010535'
+      X-Response-Time:
+      - '133'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1258154916956131328","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003Eここ数日集中力を実感していない。コードが上手く動かないことに対しての心の持ちようがあまりよくない。\u003Cbr\u003Eきっと、自分の中で仕様を決めずに後回しにしていた部分が顕在化してきて、「これを実現するぞ！」って気概が少なくなったんだ。\u003Cbr\u003E今日はそれを考えるところから始めよう。\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1258154916956131328?ref_src=twsrc%5Etfw\"\u003E2020年5月6日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1261780552950022144&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="675c225359715613c137b38224e2ff64",
+        oauth_signature="PEHM16JQZ%2FcwTlzoKlQhl%2BV8NDM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '977'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Expires:
+      - Wed, 08 May 2120 11:17:06 GMT
+      Last-Modified:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Server:
+      - tsa_m
+      Set-Cookie:
+      - guest_id=v1%3A159101022610015704; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_Vj8l54hzPKUg6y59lVFsbw=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - fd6acd0acbc8f5c20fa680d7cc9400f2
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '161'
+      X-Rate-Limit-Reset:
+      - '1591010535'
+      X-Response-Time:
+      - '190'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1261780552950022144","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003Eっていう進捗。だがしかし5日も途絶えてないんだけど……。\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E
+        \u003Ca href=\"https:\/\/t.co\/lz1GY9kfc3\"\u003Ehttps:\/\/t.co\/lz1GY9kfc3\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1261780552950022144?ref_src=twsrc%5Etfw\"\u003E2020年5月16日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1267395602662354946&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="772dd4d365cf775f6abc6c66fbe75f60",
+        oauth_signature="IBUvMCiZik5oqI7eyJ3V5AO0edg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '899'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Expires:
+      - Wed, 08 May 2120 11:17:06 GMT
+      Last-Modified:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Server:
+      - tsa_m
+      Set-Cookie:
+      - guest_id=v1%3A159101022613414182; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_5vSKu2PJRiK21haZzbn2Bg=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - f3643e7c713fc7868954fcd8884003c3
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '159'
+      X-Rate-Limit-Reset:
+      - '1591010535'
+      X-Response-Time:
+      - '123'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1267395602662354946","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
         class=\"twitter-tweet\" data-conversation=\"none\" data-lang=\"ja\"\u003E\u003Cp
-        lang=\"ja\" dir=\"ltr\"\u003E書いた。リファクタリングにより、180行から160行になりました。\u003Ca href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
-        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1256251076820389894?ref_src=twsrc%5Etfw\"\u003E2020年5月1日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
-    http_version: null
-  recorded_at: Sat, 02 May 2020 06:45:55 GMT
+        lang=\"ja\" dir=\"ltr\"\u003E直りました。モックが壊れました。かなしいです。\u003Ca href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1267395602662354946?ref_src=twsrc%5Etfw\"\u003E2020年6月1日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1255806887917830144&lang=ja&omit_script=true
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1259101828609765376&lang=ja&omit_script=true
     body:
       encoding: UTF-8
       string: ''
@@ -220,9 +623,9 @@ http_interactions:
       User-Agent:
       - TwitterRubyGem/7.0.0
       Authorization:
-      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="b8780574a2eb38818ac5f0cd82dafa80",
-        oauth_signature="vUnWzyBl09BLA9LqG3zup5GfFiw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588401955", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="07b8b5c4a1d3665162844dddda59eee8",
+        oauth_signature="gorwVpDqI0ORxO4YuBv2cP6%2FNVA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
       Connection:
       - close
       Host:
@@ -239,26 +642,26 @@ http_interactions:
       Content-Disposition:
       - attachment; filename=json.json
       Content-Length:
-      - '951'
+      - '1025'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 02 May 2020 06:45:55 GMT
+      - Mon, 01 Jun 2020 11:17:06 GMT
       Expires:
-      - Mon, 08 Apr 2120 06:45:55 GMT
+      - Wed, 08 May 2120 11:17:06 GMT
       Last-Modified:
-      - Sat, 02 May 2020 06:45:55 GMT
+      - Mon, 01 Jun 2020 11:17:06 GMT
       Server:
       - tsa_m
       Set-Cookie:
-      - guest_id=v1%3A158840195551087697; Max-Age=63072000; Expires=Mon, 2 May 2022
-        06:45:55 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
-      - personalization_id="v1_Kzw6lIqdDwLeOGsDTNGtdw=="; Max-Age=63072000; Expires=Mon,
-        2 May 2022 06:45:55 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id=v1%3A159101022613326009; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_/wmlNtqWOlpOQfsPsWtO9Q=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=631138519
       X-Connection-Hash:
-      - 399f3047fd494a14006a422979848a66
+      - bc14aaef7400522e332548269d4dba35
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -266,24 +669,23 @@ http_interactions:
       X-Rate-Limit-Limit:
       - '180'
       X-Rate-Limit-Remaining:
-      - '177'
+      - '160'
       X-Rate-Limit-Reset:
-      - '1588402855'
+      - '1591010535'
       X-Response-Time:
-      - '116'
+      - '127'
       X-Xss-Protection:
       - '0'
     body:
       encoding: UTF-8
-      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1255806887917830144","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
-        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003E・ActiveJob完全に理解した。\u003Cbr\u003E・async、awaitについて真面目に学ばなければならない日が来てしまった。\u003Ca
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1259101828609765376","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003Eデータ更新がわりと理想の挙動してくれている！\u003Cbr\u003Eただ、v-modelでテキストエリアとかとリンクしているから、キャンセル時に戻すのはどうすればいいんだ？\u003Ca
         href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
-        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1255806887917830144?ref_src=twsrc%5Etfw\"\u003E2020年4月30日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
-    http_version: null
-  recorded_at: Sat, 02 May 2020 06:45:55 GMT
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1259101828609765376?ref_src=twsrc%5Etfw\"\u003E2020年5月9日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1255343018363756544&lang=ja&omit_script=true
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1260885987271438337&lang=ja&omit_script=true
     body:
       encoding: UTF-8
       string: ''
@@ -291,9 +693,9 @@ http_interactions:
       User-Agent:
       - TwitterRubyGem/7.0.0
       Authorization:
-      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="cb275898658cc1fa0330d86f77aa6e5d",
-        oauth_signature="%2F1xr3u1vg6uhTmNdCKON3AJb1zQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588401955", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="eb4e49d4fc8b569f51b30851acdf39e7",
+        oauth_signature="i5egIRKkJnjFesD1eRi0dFgXOTY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
       Connection:
       - close
       Host:
@@ -310,26 +712,26 @@ http_interactions:
       Content-Disposition:
       - attachment; filename=json.json
       Content-Length:
-      - '1015'
+      - '828'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 02 May 2020 06:45:55 GMT
+      - Mon, 01 Jun 2020 11:17:06 GMT
       Expires:
-      - Mon, 08 Apr 2120 06:45:55 GMT
+      - Wed, 08 May 2120 11:17:06 GMT
       Last-Modified:
-      - Sat, 02 May 2020 06:45:55 GMT
+      - Mon, 01 Jun 2020 11:17:06 GMT
       Server:
       - tsa_m
       Set-Cookie:
-      - guest_id=v1%3A158840195569171241; Max-Age=63072000; Expires=Mon, 2 May 2022
-        06:45:55 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
-      - personalization_id="v1_g/0AK1tHl2fZUcF5IAb4AA=="; Max-Age=63072000; Expires=Mon,
-        2 May 2022 06:45:55 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id=v1%3A159101022614343433; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_Tzd1sy07u7ALcclhldejXw=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=631138519
       X-Connection-Hash:
-      - 1ea704c1197e6215683685ace1aedf09
+      - c57a3b3cd4b7e405f3ec8f65a67e879e
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -337,19 +739,370 @@ http_interactions:
       X-Rate-Limit-Limit:
       - '180'
       X-Rate-Limit-Remaining:
-      - '176'
+      - '158'
       X-Rate-Limit-Reset:
-      - '1588402855'
+      - '1591010535'
       X-Response-Time:
-      - '116'
+      - '130'
       X-Xss-Protection:
       - '0'
     body:
       encoding: UTF-8
-      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1255343018363756544","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
-        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003E自分が使用者にならんといけないので、とりあえず一日一回は呟きます。\u003Cbr\u003Eツイート自動収集はできたけど、status:401のときのjsonが取得できません。\u003Ca
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1260885987271438337","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003EVueやりたくない期\u003Ca
         href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
-        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1255343018363756544?ref_src=twsrc%5Etfw\"\u003E2020年4月29日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
-    http_version: null
-  recorded_at: Sat, 02 May 2020 06:45:55 GMT
-recorded_with: VCR 5.1.0
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1260885987271438337?ref_src=twsrc%5Etfw\"\u003E2020年5月14日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1267360976967397377&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="770444619e9001354385d4daa1794c22",
+        oauth_signature="WthAMAN0lYWi6YC9dvaPnQQbXF8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '863'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Expires:
+      - Wed, 08 May 2120 11:17:06 GMT
+      Last-Modified:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Server:
+      - tsa_m
+      Set-Cookie:
+      - guest_id=v1%3A159101022617781749; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_uRtHogLIryowJxM8NVl/1w=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 6ff6ba5184b5c2e6e441be661536990e
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '157'
+      X-Rate-Limit-Reset:
+      - '1591010535'
+      X-Response-Time:
+      - '121'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1267360976967397377","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003E致命的な欠陥を見つけてしまったとだけ……\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1267360976967397377?ref_src=twsrc%5Etfw\"\u003E2020年6月1日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1266302400849047552&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="b7590a7cacda6af8d88ee17402c38cc3",
+        oauth_signature="ZrOzKvvkCF8PfEBeNl7pUWYemHw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1036'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Expires:
+      - Wed, 08 May 2120 11:17:06 GMT
+      Last-Modified:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Server:
+      - tsa_m
+      Set-Cookie:
+      - guest_id=v1%3A159101022618003894; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_xAoWNkZbUz6BQcGwEsKKzQ=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - dd221fe25bbc44cf36646cfa999d3a5b
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '156'
+      X-Rate-Limit-Reset:
+      - '1591010535'
+      X-Response-Time:
+      - '121'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1266302400849047552","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003EQ.
+        実装を進めていくに従って理解度は深まるはずなのに、全然スイスイ書けないのはどうして？\u003Cbr\u003E\u003Cbr\u003EA. 過去のお前が楽なところを先に実装しているからやで\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1266302400849047552?ref_src=twsrc%5Etfw\"\u003E2020年5月29日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1266986618834968579&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="ae72d92d59734e0b0bc57e9f5b1c22cb",
+        oauth_signature="%2FAG0AdU5CU7zWrCZ7lj1rwdtBAY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '989'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Expires:
+      - Wed, 08 May 2120 11:17:06 GMT
+      Last-Modified:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Server:
+      - tsa_m
+      Set-Cookie:
+      - guest_id=v1%3A159101022619518181; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_irMaqgUdhnyce1BZs/vQKQ=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 96096c46b80b0c0b5a7482c9ba590dca
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '154'
+      X-Rate-Limit-Reset:
+      - '1591010535'
+      X-Response-Time:
+      - '123'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1266986618834968579","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003Eポートフォリオ勢誰も言ってなかったんだけど、利用規約書くのしんどくないですか……？\u003Cbr\u003E抑えるポイントがさっぱどわからん\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1266986618834968579?ref_src=twsrc%5Etfw\"\u003E2020年5月31日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1262320895525191681&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="52c82862fb929f7d34d9937ae615357a",
+        oauth_signature="%2FfCX%2FQF9Bl%2BfCp75REwgthfF21w%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '908'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Expires:
+      - Wed, 08 May 2120 11:17:06 GMT
+      Last-Modified:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Server:
+      - tsa_m
+      Set-Cookie:
+      - guest_id=v1%3A159101022619429593; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_WWFaLRzZWExD1JypEw9Flg=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - f4879a0ce085b53846b74c98fb5899d4
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '155'
+      X-Rate-Limit-Reset:
+      - '1591010535'
+      X-Response-Time:
+      - '127'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1262320895525191681","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003Eぴえん。\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E
+        \u003Ca href=\"https:\/\/t.co\/TVAgVohdue\"\u003Epic.twitter.com\/TVAgVohdue\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1262320895525191681?ref_src=twsrc%5Etfw\"\u003E2020年5月18日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1258796536793718784&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="ab2bd410ff6fbdadcf7bfb24b42c55d2",
+        oauth_signature="8R7wAwgmKzNhrsmNxKuyGPFqcoE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1591010225", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1061'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Expires:
+      - Wed, 08 May 2120 11:17:06 GMT
+      Last-Modified:
+      - Mon, 01 Jun 2020 11:17:06 GMT
+      Server:
+      - tsa_m
+      Set-Cookie:
+      - guest_id=v1%3A159101022625726028; Max-Age=63072000; Expires=Wed, 1 Jun 2022
+        11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_WrayPxYavUkmXtSiWNtqmw=="; Max-Age=63072000; Expires=Wed,
+        1 Jun 2022 11:17:06 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 8e4d840f910254ba3919321ac7b7c2e3
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '153'
+      X-Rate-Limit-Reset:
+      - '1591010535'
+      X-Response-Time:
+      - '120'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/aiandrox\/status\/1258796536793718784","author_name":"END","author_url":"https:\/\/twitter.com\/aiandrox","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003Eレスポンシブ対応をちゃんとしたいと考えると、Vueにしたのはそんなによくなかったかもしれない。\u003Cbr\u003Eそしてページ遷移時にトランザクションができない。Vuetifyに歩み寄らねば……。\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#ポートフォリオ進捗\u003C\/a\u003E\u003C\/p\u003E&mdash;
+        END (@aiandrox) \u003Ca href=\"https:\/\/twitter.com\/aiandrox\/status\/1258796536793718784?ref_src=twsrc%5Etfw\"\u003E2020年5月8日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Mon, 01 Jun 2020 11:17:06 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/twitter_api/standard_search.yml
+++ b/spec/vcr_cassettes/twitter_api/standard_search.yml
@@ -4,7 +4,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97%20from:aiandrox&result_type=recent
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%80%B2%E6%8D%97%20from:aiandrox%20exclude:retweets&result_type=recent
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/standard_search/該当のツイートがない場合.yml
+++ b/spec/vcr_cassettes/twitter_api/standard_search/該当のツイートがない場合.yml
@@ -4,7 +4,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23absent_tag%20from:aiandrox&result_type=recent
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23absent_tag%20from:aiandrox%20exclude:retweets&result_type=recent
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/standard_search_test.yml
+++ b/spec/vcr_cassettes/twitter_api/standard_search_test.yml
@@ -4,7 +4,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%86%E3%82%B9%E3%83%88%20from:aiandrox&result_type=recent
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23%E3%83%86%E3%82%B9%E3%83%88%20from:aiandrox%20exclude:retweets&result_type=recent
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr_cassettes/twitter_api/standard_search_with_absent_tag.yml
+++ b/spec/vcr_cassettes/twitter_api/standard_search_with_absent_tag.yml
@@ -4,7 +4,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23absent_tag%20from:aiandrox&result_type=recent
+    uri: https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23absent_tag%20from:aiandrox%20exclude:retweets&result_type=recent
     body:
       encoding: UTF-8
       string: ''


### PR DESCRIPTION
## 概要

- userのnameのバリデーションを30字→50字に変更
  - Twitterのuser_nameの規定に揃えた
- ツイート取得時にリツイートを除外していなかったので、除外するようにした
  - standard_searchでは、クエリに`execlude:retweets`を渡す
  - premium_searchでは、each内で`result.retweeted_status.present?`で判定する
  - それに伴いRSpecのモックを修正
- TwitterAPIモジュール内のリファクタリング

## コメント

そんなに変えていません。
premiumの方で`if result.retweeted_status`ではなく`present?`を付けているのは、（なぜか）リツイートではない場合は空白？になっているので。

↓通常ツイート
<img width="467" alt="スクリーンショット 2020-06-01 21 21 36" src="https://user-images.githubusercontent.com/44717752/83408634-e9319800-a44d-11ea-8525-cf195228aa78.png">

↓リツイート
<img width="428" alt="スクリーンショット 2020-06-01 21 22 00" src="https://user-images.githubusercontent.com/44717752/83408661-f64e8700-a44d-11ea-97dd-6b933e5ff74d.png">
## 参考資料

https://developer.twitter.com/en/docs/tweets/search/guides/premium-operators
