### PR TITLE
表示に必要なエンドポイントの追加

### DIFF
--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::TagsController < Api::V1::BaseController
   def index
-    @pagy, tags = pagy(Tag.all)
+    if (count = params[:count])
+      tags = Tag.popular.limit(count)
+    else
+      @pagy, tags = pagy(Tag.popular)
+    end
     render json: tags
   end
 end

--- a/app/javascript/pages/Top.vue
+++ b/app/javascript/pages/Top.vue
@@ -2,35 +2,26 @@
   <div>
     <v-btn text href="/api/v1/oauth/twitter">ログイン</v-btn>
     <v-btn text :to="{ name: 'mypage' }">マイページ</v-btn>
-    <v-btn text :to="{ name: 'user', params: { userUuid: 'HTagphtz9-sM' } }"
-      >ユーザーページ</v-btn
-    >
+    <v-btn text :to="{ name: 'user', params: { userUuid: 'HTagphtz9-sM' } }">ユーザーページ</v-btn>
     <v-btn text>ログアウト</v-btn>
+    人気ハッシュタグ{{ tags }}
   </div>
 </template>
 
 <script>
 export default {
   data: () => ({
-    name: "",
-    email: "",
-    select: null,
-    items: ["Item 1", "Item 2", "Item 3", "Item 4"],
-    checkbox: null
+    tags: []
   }),
   mounted() {
     document.title = "Hashlog"
+    this.fetchTagsData()
   },
   methods: {
-    submit() {
-      this.$refs.observer.validate()
-    },
-    clear() {
-      this.name = ""
-      this.email = ""
-      this.select = null
-      this.checkbox = null
-      this.$refs.observer.reset()
+    async fetchTagsData() {
+      const tagsRes = await this.$axios.get("/api/v1/tags?count=3")
+      const { tags } = tagsRes.data
+      this.tags = tags
     }
   }
 }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,4 +3,7 @@ class Tag < ApplicationRecord
   has_many :users, through: :registered_tags
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 100 }
+
+  # TODO: 警告を直す
+  scope :popular, -> { joins(:registered_tags).group(:tag_id).order('count(user_id) DESC') }
 end

--- a/spec/models/registered_tag_spec.rb
+++ b/spec/models/registered_tag_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RegisteredTag, type: :model do
   end
 
   describe 'scopes' do
-    describe 'asc' do
+    describe '.asc' do
       let!(:latest_tag) { create(:registered_tag) }
       let!(:oldest_tag) { create(:registered_tag, :created_yesterday) }
       it 'created_atを基準に昇順に並ぶこと' do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -9,4 +9,21 @@ RSpec.describe Tag, type: :model do
     it { is_expected.to validate_uniqueness_of(:name) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
   end
+
+  describe 'scope' do
+    describe '.popular' do
+      let(:popular_tag) { create(:tag, name: 'the most popular tag') }
+      let(:not_popular_tag) { create(:tag, name: 'not most popular tag') }
+      before do
+        create_list(:registered_tag, 5, tag: popular_tag)
+        create_list(:registered_tag, 1, tag: not_popular_tag)
+        create_list(:registered_tag, 3, tag: create(:tag))
+      end
+      it '紐付いたregistered_tagが多い順に並ぶ' do
+        expect(Tag.popular.length).to eq 3
+        expect(Tag.popular.first).to eq popular_tag
+        expect(Tag.popular.last).to eq not_popular_tag
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/tags_spec.rb
+++ b/spec/requests/api/v1/tags_spec.rb
@@ -1,22 +1,32 @@
 RSpec.describe 'Tags', type: :request do
   describe 'GET /api/v1/tags' do
-    let(:popular_tag) { create(:tag)}
+    let(:popular_tag) { create(:tag) }
     let(:tags) { Tag.popular }
     let(:tags_json) { json['tags'] }
-    before do
-      create_list(:registered_tag, 3, tag: popular_tag)
-      create_list(:registered_tag, 10)
-      get '/api/v1/tags'
-    end
-    it '200 OKを返す' do
-      expect(response.status).to eq 200
-    end
-    it 'tagsが人気順に並ぶ' do
-      expect(tags_json.first['id']).to eq popular_tag.id
+    describe '全般的なこと' do
+      before do
+        create_list(:registered_tag, 3, tag: popular_tag)
+        create_list(:registered_tag, 10)
+        get '/api/v1/tags'
+      end
+      it '200 OKを返す' do
+        expect(response.status).to eq 200
+      end
+      it 'Tag.popularのJSONを返す' do
+        tags_json.zip(tags).each do |tag_json, tag|
+          expect(tag_json).to eq({
+            'id' => tag.id,
+            'name' => tag.name,
+          })
+        end
+      end
+      it 'tagsが人気順に並ぶ' do
+        expect(tags_json.first['id']).to eq popular_tag.id
+      end
     end
     context 'countクエリがないとき' do
       before do
-        create_list(:registered_tag, 30)
+        create_list(:registered_tag, 50)
         get '/api/v1/tags'
       end
       describe 'pagy' do
@@ -28,18 +38,13 @@ RSpec.describe 'Tags', type: :request do
           expect(tags_json.length).to eq 20
         end
       end
-      it 'Tag.popularのJSONを返す' do
-        tags_json.zip(tags).each do |tag_json, tag|
-          expect(tag_json).to eq({
-            'id' => tag.id,
-            'name' => tag.name,
-          })
-        end
-      end
     end
     context 'countクエリがあるとき' do
-      let(:count) { rand(5) }
-      before { get "/api/v1/tags?count=#{count}" }
+      let(:count) { rand(1..5) }
+      before do
+        create_list(:registered_tag, 10)
+        get "/api/v1/tags?count=#{count}"
+      end
       it '200 OKを返す' do
         expect(response.status).to eq 200
       end

--- a/spec/requests/api/v1/tags_spec.rb
+++ b/spec/requests/api/v1/tags_spec.rb
@@ -1,34 +1,51 @@
 RSpec.describe 'Tags', type: :request do
   describe 'GET /api/v1/tags' do
-    let(:tags) { Tag.all }
+    let(:popular_tag) { create(:tag)}
+    let(:tags) { Tag.popular }
     let(:tags_json) { json['tags'] }
     before do
-      create_list(:registered_tag, 50)
+      create_list(:registered_tag, 3, tag: popular_tag)
+      create_list(:registered_tag, 10)
       get '/api/v1/tags'
-    end
-    describe 'pagy' do
-      it 'pageクエリがないとき 20件返す' do
-        expect(tags_json.length).to eq 20
-      end
-      it 'page=2のとき 20件返す' do
-        get '/api/v1/tags?page=2'
-        expect(tags_json.length).to eq 20
-      end
     end
     it '200 OKを返す' do
       expect(response.status).to eq 200
     end
-    it 'Tag.allのJSONを返す' do
-      tags_json.zip(tags).each do |tag_json, tag|
-        expect(tag_json).to eq({
-          'id' => tag.id,
-          'name' => tag.name,
-        })
+    it 'tagsが人気順に並ぶ' do
+      expect(tags_json.first['id']).to eq popular_tag.id
+    end
+    context 'countクエリがないとき' do
+      before do
+        create_list(:registered_tag, 30)
+        get '/api/v1/tags'
+      end
+      describe 'pagy' do
+        it 'pageクエリがないとき 20件返す' do
+          expect(tags_json.length).to eq 20
+        end
+        it 'page=2のとき 20件返す' do
+          get '/api/v1/tags?page=2'
+          expect(tags_json.length).to eq 20
+        end
+      end
+      it 'Tag.popularのJSONを返す' do
+        tags_json.zip(tags).each do |tag_json, tag|
+          expect(tag_json).to eq({
+            'id' => tag.id,
+            'name' => tag.name,
+          })
+        end
       end
     end
-    xit 'tagsが降順に並ぶ' do # 並び順は今のところ指定なし。強いて言うなら人気順になる気がする。
-      expect(tags_json.first['id']).to eq oldest_registered_tag.id
-      expect(tags_json.last['id']).to eq latest_registered_tag.id
+    context 'countクエリがあるとき' do
+      let(:count) { rand(5) }
+      before { get "/api/v1/tags?count=#{count}" }
+      it '200 OKを返す' do
+        expect(response.status).to eq 200
+      end
+      it 'countで指定したレコード数を返す' do
+        expect(tags_json.length).to eq count
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
#25 

```
GET   /api/v1/tags      TagController#index
全てのタグを「登録している人が多い（has_many registered_tagsが多い）順」で返す
```
クエリに`count`を許可し、countがある場合は上位から指定の数のtagを返す
この数は、公開非公開は関係無しで全てのregistered_tagを数えている