### PR TITLE
[Pend] 'api/v1/tags/:id/registered_tags'を追加（したい）

### DIFF
--- a/app/controllers/api/v1/tag_registered_tags_controller.rb
+++ b/app/controllers/api/v1/tag_registered_tags_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::TagRegisteredTagsController < Api::V1::BaseController
+  # TODO: 同じハッシュタグのregistered_tagsを返す。テストも書けていない。
+  def index
+    tag = Tag.find(params[:tag_id])
+    registered_tags = tag.registered_tags.published
+    if (count = params[:count])
+      registered_tags.limit!(count)
+    else
+      @pagy, registered_tags = pagy(registered_tags)
+    end
+    render json: registered_tags
+    # user.nameを含む。自らのリソース（RegisteredTag.find_by(tag_id: tag.id)）は含まない
+  end
+end

--- a/spec/requests/api/v1/tag_registered_tags_spec.rb
+++ b/spec/requests/api/v1/tag_registered_tags_spec.rb
@@ -1,0 +1,76 @@
+RSpec.xdescribe 'TagRegisteredTags', type: :request do
+  describe 'GET /api/v1/tags/:id/registered_tags' do
+    let(:tag) { create(:tag) }
+    let(:tags_json) { json['registeredTags'] }
+    let!(:tag_registered_tag) { create(:registered_tag, tag: tag) }
+    let!(:other_registered_tag) { create(:registered_tag) }
+
+    describe '全般的なこと' do
+      before do
+        create_list(:registered_tag, 10, tag: tag)
+        get "/api/v1/tags/#{tag.id}/registered_tags"
+      end
+      it '200 OKを返す' do
+        expect(response.status).to eq 200
+      end
+      it '指定のハッシュタグのregistered_tagのみ含む' do
+        # expect(json['registeredTags']).to include tag_registered_tag.tag.name
+        # expect(json['registeredTags']).not_to include other_registered_tag.tag.name
+      end
+      it 'Tag.registered_tagsのJSONを返す' do
+        registered_tags = tag.registered_tags
+        tags_json.zip(registered_tags).each do |tag_json, registered_tag|
+          expect(tag_json).to eq({
+            'id' => registered_tag.id,
+            'tweetedDayCount' => registered_tag.tweeted_day_count,
+            'privacy' => registered_tag.privacy_i18n,
+            'remindDay' => registered_tag.remind_day,
+            'firstTweetedAt' => registered_tag.first_tweeted_at,
+            'lastTweetedAt' => registered_tag.last_tweeted_at,
+            'tag' => {
+              'id' => registered_tag.tag.id,
+              'name' => registered_tag.tag.name,
+            }
+          })
+        end
+      end
+      context 'registered_tagが限定公開のとき' do
+        let(:limited_registered_tag) { create(:registered_tag, :limited, tag: tag) }
+        it '含まない' do
+
+        end
+      end
+      context 'registered_tagが非公開のとき' do
+        let(:closed_registered_tag) { create(:registered_tag, :closed, tag: tag) }
+        it '含まない' do
+        end
+      end
+    end
+
+    context 'countクエリがないとき' do
+      describe 'pagy' do
+        before do
+          create_list(:registered_tag, 50, tag: tag)
+          get "/api/v1/tags/#{tag.id}/registered_tags"
+        end
+        it 'pageクエリがないとき 20件返す' do
+          expect(tags_json.length).to eq 20
+        end
+        it 'page=2のとき 20件返す' do
+          get '/api/v1/tags?page=2'
+          expect(tags_json.length).to eq 20
+        end
+      end
+    end
+    context 'countクエリがあるとき' do
+      let(:count) { rand(1..5) }
+      before do
+        create_list(:registered_tag, 10, tag: tag)
+        get "/api/v1/tags/#{tag.id}/registered_tags?count=#{count}"
+      end
+      it 'countで指定したレコード数を返す' do
+        expect(tags_json.length).to eq count
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
close #25

```
GET   /api/v1/tags/:id/registered_tags     TagRegisteredTagController#index
ハッシュタグに紐づくタグを返す（公開設定のもののみ）
```

`count`クエリを許可する。countがある場合はその数レコードを返す。


## 使用gemや外部ツール


## 確認手順

1. Gem を追加したので `bundle install` を実行してください
2. カラムを追加したので `bundle exec rails db:migrate` を実行してください

## 想定される影響範囲

- データベース
- gem

## コメント

- レビュワーに見てほしい点
- 気づき

## 参考資料

公式リファレンスや参考記事へのリンク