### PR TITLE
継続率ランキング

### DIFF
--- a/app/controllers/api/v1/registered_tags/persistences_controller.rb
+++ b/app/controllers/api/v1/registered_tags/persistences_controller.rb
@@ -1,0 +1,9 @@
+require 'pagy/extras/array'
+
+class Api::V1::RegisteredTags::PersistencesController < Api::V1::BaseController
+  def index
+    registered_tags = RegisteredTag.opened.includes(:user, :tag).persistence_sort
+    @pagy, registered_tags = pagy_array(registered_tags)
+    render json: registered_tags
+  end
+end

--- a/app/javascript/components/TheTagWrapper.vue
+++ b/app/javascript/components/TheTagWrapper.vue
@@ -12,7 +12,7 @@
       :tweet-dates="tweetDates"
       @input-date="fetchDateTweets"
     />
-    <v-container class="main-content d-flex flex-row-reverse pt-0" row>
+    <v-container class="main-content d-flex flex-row-reverse pt-0 px-0" row>
       <!-- ハッシュタグの情報 -->
       <v-col cols="12" md="4">
         <v-card flat>

--- a/app/javascript/components/shared/TheHeader.vue
+++ b/app/javascript/components/shared/TheHeader.vue
@@ -5,6 +5,9 @@
     </v-toolbar-title>
     <v-spacer />
     <v-toolbar-items>
+      <v-btn v-if="isTopPage" text :to="{ name: 'tagRanking' }"
+        >継続率ランキング</v-btn
+      >
       <v-btn v-if="!currentUser" text @click="pushLogin">ログイン</v-btn>
       <v-btn v-if="currentUser" text :to="{ name: 'mypage' }">マイページ</v-btn>
       <v-btn v-if="currentUser" text @click="logout">ログアウト</v-btn>

--- a/app/javascript/packs/router.js
+++ b/app/javascript/packs/router.js
@@ -2,6 +2,7 @@ import VueRouter from "vue-router"
 
 import store from "../store"
 import Top from "../pages/Top"
+import TagRanking from "../pages/TagRanking"
 import Terms from "../pages/Terms"
 import Mypage from "../pages/Mypage"
 import MyTag from "../pages/MyTag"
@@ -19,6 +20,11 @@ const routes = [
     path: "/terms",
     name: "terms",
     component: Terms
+  },
+  {
+    path: "/ranking/persistence",
+    name: "tagRanking",
+    component: TagRanking
   },
   {
     path: "/mypage/dashboard",

--- a/app/javascript/pages/TagRanking.vue
+++ b/app/javascript/pages/TagRanking.vue
@@ -1,0 +1,91 @@
+<template>
+  <div>
+    <h2 class="text-center my-7">継続率ランキング</h2>
+    <!-- ランキング -->
+    <v-card max-width="700" class="mx-auto mb-7">
+      <v-list two-line subheader>
+        <v-list-item
+          v-for="(tag, index) in registeredTags"
+          :key="tag.id"
+          :to="{
+            name: 'userTag',
+            params: { tagId: tag.id, userUuid: tag.user.uuid }
+          }"
+        >
+          <v-list-item-avatar>
+            <v-icon>{{ index + 1 }}</v-icon>
+          </v-list-item-avatar>
+
+          <v-list-item-avatar color="grey" size="50" class="mr-7">
+            <v-img :src="tag.user.avatarUrl" />
+          </v-list-item-avatar>
+
+          <v-list-item-content>
+            <v-list-item-title v-text="'#' + tag.tag.name" />
+            <v-list-item-subtitle class="mt-1" v-text="'by ' + tag.user.name" />
+          </v-list-item-content>
+
+          <v-list-item-action>{{ tag.tweetRate }}%</v-list-item-action>
+          <v-list-item-action class="d-none d-md-flex"
+            >（{{ tag.tweetedDayCount }}日）</v-list-item-action
+          >
+        </v-list-item>
+      </v-list>
+    </v-card>
+    <!-- ページネーション -->
+    <div class="text-center">
+      <v-pagination
+        v-model="page.currentPage"
+        :length="page.totalPages"
+        :total-visible="7"
+        @input="changePaginationPage"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      page: {
+        currentPage: 1,
+        totalPages: 1,
+        requestUrl: ""
+      },
+      registeredTags: []
+    }
+  },
+  mounted() {
+    this.fetchRegisteredTagsData()
+    document.title = "継続率ランキング | Hashlog"
+  },
+  methods: {
+    async fetchRegisteredTagsData() {
+      const registeredTagsRes = await this.$axios.get(
+        "/api/v1/registered_tags/persistences"
+      )
+      this.setPaginationData(registeredTagsRes)
+      const { registeredTags } = registeredTagsRes.data
+      this.registeredTags = registeredTags
+    },
+    // ページネーション
+    setPaginationData(response) {
+      this.page.totalPages = Number(response.headers["total-pages"])
+      this.page.requestUrl = response.headers["request-url"]
+    },
+    async changePaginationPage(val) {
+      this.$toTop(0)
+      const res = await this.$axios.get(`${this.page.requestUrl}?page=${val}`)
+      const { registeredTags } = res.data
+      this.registeredTags = registeredTags
+    }
+  }
+}
+</script>
+
+<style scoped>
+h2 {
+  color: #3b394d;
+}
+</style>

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -16,6 +16,10 @@ class RegisteredTag < ApplicationRecord
   scope :desc, -> { order(created_at: :desc) }
   scope :opened, -> { published.joins(:user).where('users.privacy = ?', 0) }
 
+  def self.persistence_sort
+    all.sort_by(&:tweet_rate).reverse
+  end
+
   def last_tweeted_at
     @last_tweeted_at ||= tweets.latest&.tweeted_at
   end

--- a/app/serializers/registered_tag_serializer.rb
+++ b/app/serializers/registered_tag_serializer.rb
@@ -13,6 +13,6 @@ class RegisteredTagSerializer < ActiveModel::Serializer
   end
 
   class UserSerializer < ActiveModel::Serializer
-    attributes :uuid, :name
+    attributes :uuid, :name, :avatar_url
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get 'mypage/tags/:id', to: 'static_pages#top'
   get 'users/:uuid', to: 'static_pages#top'
   get 'users/:uuid/tags/:id', to: 'static_pages#top'
+  get 'ranking/persistence', to: 'static_pages#top'
 
   namespace :api do
     namespace :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,10 @@ Rails.application.routes.draw do
         end
         resources :registered_tags, only: %i[index], module: :users
       end
+      # resources :registered_tagsより上に書く
+      namespace :registered_tags do
+        resources :persistences, only: %i[index]
+      end
       resources :registered_tags, only: %i[index show create update destroy] do
         resources :tweets, only: %i[index]
       end

--- a/spec/models/registered_tag_spec.rb
+++ b/spec/models/registered_tag_spec.rb
@@ -82,6 +82,23 @@ RSpec.describe RegisteredTag, type: :model do
   end
 
   describe 'methods' do
+    describe '.persistence_sort' do
+      let!(:tag_with_42_per) { create(:registered_tag, :with_3_7_days_tweets) }
+      let(:today_tweet) { create(:tweet) }
+      let!(:tag_with_100_per) { today_tweet.registered_tag }
+      before { tag_with_100_per.fetch_tweets_data! }
+      let!(:tag_with_0_per) { create(:registered_tag) }
+      it 'tweet_rate100%のタグが最初になる' do
+        expect(RegisteredTag.persistence_sort[0]).to eq tag_with_100_per
+      end
+      it 'tweet_rate42%のタグが二番目になる' do
+        expect(RegisteredTag.persistence_sort[1]).to eq tag_with_42_per
+      end
+      it 'tweet_rate0%のタグが最後になる' do
+        expect(RegisteredTag.persistence_sort[-1]).to eq tag_with_0_per
+      end
+    end
+
     describe '#last_tweeted_at' do
       let(:registered_tag) { create(:registered_tag) }
       context 'ツイートがあるとき' do

--- a/spec/requests/api/v1/registered_tags/persistences_spec.rb
+++ b/spec/requests/api/v1/registered_tags/persistences_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'RegisteredTags', type: :request do
-  fdescribe 'GET /api/v1/registered_tags/persistences' do
+  describe 'GET /api/v1/registered_tags/persistences' do
     let(:registered_tags) { RegisteredTag.opened.includes(:user, :tag).persistence_sort }
     let(:tags_json) { json['registeredTags'] }
     before do
@@ -26,7 +26,8 @@ RSpec.describe 'RegisteredTags', type: :request do
             },
             'user' => {
               'name' => registered_tag.user.name,
-              'uuid' => registered_tag.user.uuid
+              'uuid' => registered_tag.user.uuid,
+              'avatarUrl' => 'https://abs.twimg.com/sticky/default_profile_images/default_profile.png'
             }
           })
         end

--- a/spec/requests/api/v1/registered_tags/persistences_spec.rb
+++ b/spec/requests/api/v1/registered_tags/persistences_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe 'RegisteredTags', type: :request do
+  fdescribe 'GET /api/v1/registered_tags/persistences' do
+    let(:registered_tags) { RegisteredTag.opened.includes(:user, :tag).persistence_sort }
+    let(:tags_json) { json['registeredTags'] }
+    before do
+      create_list(:registered_tag, 50)
+      get '/api/v1/registered_tags/persistences'
+    end
+    describe '全般的なこと' do
+      it '200 OKを返す' do
+        expect(response.status).to eq 200
+      end
+      it 'RegisteredTag.ascのJSONを返す' do
+        tags_json.zip(registered_tags).each do |tag_json, registered_tag|
+          expect(tag_json).to eq({
+            'id' => registered_tag.id,
+            'tweetedDayCount' => registered_tag.tweeted_day_count,
+            'privacy' => registered_tag.privacy_i18n,
+            'remindDay' => nil,
+            'tweetRate' => 0,
+            'firstTweetedAt' => registered_tag.first_tweeted_at,
+            'lastTweetedAt' => registered_tag.last_tweeted_at,
+            'tag' => {
+              'id' => registered_tag.tag.id,
+              'name' => registered_tag.tag.name,
+            },
+            'user' => {
+              'name' => registered_tag.user.name,
+              'uuid' => registered_tag.user.uuid
+            }
+          })
+        end
+      end
+    end
+    describe 'ソート' do
+      let!(:tag_with_42_per) { create(:registered_tag, :with_3_7_days_tweets) }
+      let(:today_tweet) { create(:tweet) }
+      let!(:tag_with_100_per) { today_tweet.registered_tag }
+      before { tag_with_100_per.fetch_tweets_data! }
+      it 'ツイートの割合が多い順に並ぶ' do
+        get '/api/v1/registered_tags/persistences'
+        expect(tags_json.first['id']).to eq tag_with_100_per.id
+        expect(tags_json.second['id']).to eq tag_with_42_per.id
+      end
+    end
+    describe '公開設定' do
+      let!(:limited_registered_tag) { create(:registered_tag, :limited) }
+      let!(:closed_registered_tag) { create(:registered_tag, :closed) }
+      it '限定公開のタグを返さない' do
+        expect(tags_json).not_to include 'id' => limited_registered_tag.id
+        get '/api/v1/registered_tags/persistences?page=2'
+        expect(tags_json).not_to include 'id' => limited_registered_tag.id
+        get '/api/v1/registered_tags/persistences?page=3'
+        expect(tags_json).not_to include 'id' => limited_registered_tag.id
+      end
+      it '非公開のタグを返さない' do
+        expect(tags_json).not_to include 'id' => closed_registered_tag.id
+        get '/api/v1/registered_tags/persistences?page=2'
+        expect(tags_json).not_to include 'id' => closed_registered_tag.id
+        get '/api/v1/registered_tags/persistences?page=3'
+        expect(tags_json).not_to include 'id' => closed_registered_tag.id
+      end
+    end
+    describe 'pagy' do
+      it 'pageクエリがないとき 20件返す' do
+        expect(tags_json.length).to eq 20
+      end
+      it 'page=2のとき 10件返す' do
+        get '/api/v1/registered_tags/persistences?page=2'
+        expect(tags_json.length).to eq 20
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/registered_tags_spec.rb
+++ b/spec/requests/api/v1/registered_tags_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe 'RegisteredTags', type: :request do
             },
             'user' => {
               'name' => registered_tag.user.name,
-              'uuid' => registered_tag.user.uuid
+              'uuid' => registered_tag.user.uuid,
+              'avatarUrl' => 'https://abs.twimg.com/sticky/default_profile_images/default_profile.png'
             }
           })
         end
@@ -110,7 +111,8 @@ RSpec.describe 'RegisteredTags', type: :request do
           },
           'user' => {
             'name' => registered_tag.user.name,
-            'uuid' => registered_tag.user.uuid
+            'uuid' => registered_tag.user.uuid,
+            'avatarUrl' => 'https://abs.twimg.com/sticky/default_profile_images/default_profile.png'
           }
         })
       end
@@ -207,7 +209,8 @@ RSpec.describe 'RegisteredTags', type: :request do
             },
             'user' => {
               'name' => registered_tag.user.name,
-              'uuid' => registered_tag.user.uuid
+              'uuid' => registered_tag.user.uuid,
+              'avatarUrl' => 'https://abs.twimg.com/sticky/default_profile_images/default_profile.png'
             }
           })
         end

--- a/spec/requests/api/v1/registered_tags_spec.rb
+++ b/spec/requests/api/v1/registered_tags_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'RegisteredTags', type: :request do
   describe 'GET /api/v1/registered_tags' do
-    let(:registered_tags) { RegisteredTag.published.desc }
+    let(:registered_tags) { RegisteredTag.opened.desc }
     let(:tags_json) { json['registeredTags'] }
     before do
       create_list(:registered_tag, 50)

--- a/spec/requests/api/v1/users/current/registered_tags_spec.rb
+++ b/spec/requests/api/v1/users/current/registered_tags_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe 'RegisteredTags', type: :request do
               },
             'user' => {
               'name' => registered_tag.user.name,
-              'uuid' => registered_tag.user.uuid
+              'uuid' => registered_tag.user.uuid,
+              'avatarUrl' => 'https://abs.twimg.com/sticky/default_profile_images/default_profile.png'
             }
           })
         end

--- a/spec/requests/api/v1/users/registered_tags_spec.rb
+++ b/spec/requests/api/v1/users/registered_tags_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe 'RegisteredTags', type: :request do
               },
               'user' => {
                 'name' => registered_tag.user.name,
-                'uuid' => registered_tag.user.uuid
+                'uuid' => registered_tag.user.uuid,
+                'avatarUrl' => 'https://abs.twimg.com/sticky/default_profile_images/default_profile.png'
               }
             })
           end
@@ -70,7 +71,8 @@ RSpec.describe 'RegisteredTags', type: :request do
               },
               'user' => {
                 'name' => published_registered_tag.user.name,
-                'uuid' => published_registered_tag.user.uuid
+                'uuid' => published_registered_tag.user.uuid,
+                'avatarUrl' => 'https://abs.twimg.com/sticky/default_profile_images/default_profile.png'
               }
             })
         end

--- a/spec/serializers/registered_tag_spec.rb
+++ b/spec/serializers/registered_tag_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe 'RegisteredTag', type: :request do
           },
           'user' => {
             'name' => registered_tag.user.name,
-            'uuid' => registered_tag.user.uuid
+            'uuid' => registered_tag.user.uuid,
+            'avatarUrl' => 'https://abs.twimg.com/sticky/default_profile_images/default_profile.png'
           }
         })
       end


### PR DESCRIPTION
## 概要
close #23
![image](https://user-images.githubusercontent.com/44717752/84557246-5bff1500-ad64-11ea-88a4-e01ed5bef560.png)

registered_tag.tweet_rate順にランキング

ランキング表示はもう少し凝りたかったけど、とりあえず表示させること第一で。
トップページからの動線が悩みどころ。