### PR TITLE
[Fix] なぜか通らないスペックを（一部）解消

### DIFF
--- a/app/jobs/add_tweets_job.rb
+++ b/app/jobs/add_tweets_job.rb
@@ -6,9 +6,8 @@ class AddTweetsJob < ApplicationJob
     retry_job wait: 15.minutes, queue: :low_priority
   end
 
-  def perform
+  def perform(add_tweets = TwitterAPI::AddTweets.new)
     logger.info("\n#{Time.now} : AddTweetsJob")
-    add_tweets = TwitterAPI::AddTweets.new
     add_tweets.call
     message = add_tweets.notify_logs.join("\n")
     slack_notify(message)

--- a/app/jobs/remind_reply_job.rb
+++ b/app/jobs/remind_reply_job.rb
@@ -7,9 +7,8 @@ class RemindReplyJob < ApplicationJob
   #   retry_job wait: 3.hours, queue: :low_priority
   # end
 
-  def perform
+  def perform(remind_reply = TwitterAPI::RemindReply.new)
     logger.info("\n#{Time.now} : RemindReplyJob")
-    remind_reply = TwitterAPI::RemindReply.new
     remind_reply.call
     message = remind_reply.notify_logs.join("\n")
     slack_notify(message)

--- a/app/services/twitter_api.rb
+++ b/app/services/twitter_api.rb
@@ -37,15 +37,18 @@ module TwitterAPI
     include TwitterAPIClient
     attr_reader :notify_logs
 
-    def initialize
-      @registered_tags = RegisteredTag.all.includes(:user, :tag)
+    def initialize(registered_tags = RegisteredTag.all.includes(:user, :tag))
+      @registered_tags = registered_tags
       @notify_logs = []
     end
 
     def call
       registered_tags.each do |r_tag|
         last_tweet = r_tag.tweets.latest
-        r_tag.create_tweets! && next unless last_tweet
+        unless last_tweet
+          r_tag.create_tweets!
+          next
+        end
 
         next if last_tweet.tweeted_at > Time.current.prev_day.beginning_of_day
 

--- a/spec/jobs/add_tweets_job_spec.rb
+++ b/spec/jobs/add_tweets_job_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe AddTweetsJob, type: :job do
     let(:add_tweets) { TwitterAPI::AddTweets.new }
     xit 'ログを出力する' do
       expect(Rails.logger).to receive(:info)
-      job.perform
+      job.perform(add_tweets)
     end
-    xit 'TwitterAPI::AddTweets#callを実行する' do
+    it 'TwitterAPI::AddTweets#callを実行する' do
       expect(add_tweets).to receive(:call)
-      job.perform
+      job.perform(add_tweets)
     end
     it 'slack_notofyが実行される' do
       expect(job).to receive(:slack_notify)

--- a/spec/jobs/reminder_reply_job_spec.rb
+++ b/spec/jobs/reminder_reply_job_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe RemindReplyJob, type: :job do
     end
   end
 
-  # TODO: 実行されているが……なぜ通らない
   describe 'RemindReplyJob#perform',
     vcr: { cassette_name: 'remind_reply_job Webhooks' } do
     let(:job) { RemindReplyJob.new }
@@ -19,9 +18,9 @@ RSpec.describe RemindReplyJob, type: :job do
       expect(Rails.logger).to receive(:info)
       job.perform
     end
-    xit 'TwitterAPI::RemindReply#callを実行する' do
+    it 'TwitterAPI::RemindReply#callを実行する' do
       expect(remind_reply).to receive(:call)
-      job.perform
+      job.perform(remind_reply)
     end
     it 'slack_notofyが実行される' do
       expect(job).to receive(:slack_notify)

--- a/spec/services/twitter_api_spec.rb
+++ b/spec/services/twitter_api_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe TwitterAPI do
     end
   end
 
-  # TODO: モックのテストが通らない…
   describe '::AddTweets' do
     let(:registered_tag) { user.registered_tags.first }
     let(:tag) { create(:tag, name: 'ポートフォリオ進捗') }
@@ -44,13 +43,14 @@ RSpec.describe TwitterAPI do
               add_tweets.call
             end.to change(Tweet, :count).by(3)
           end
-          xit 'Rails.logger.infoでログを出力する' do
+          it 'Rails.logger.infoでログを出力する' do
             expect(Rails.logger).to receive(:info).with('@aiandrox の #ポートフォリオ進捗 にツイートを追加')
             add_tweets.call
           end
         end
         context '既に前日のツイートを取得しているとき' do
-          xit 'RegisteredTag#add_tweetsを実行しない' do
+          let(:add_tweets) { TwitterAPI::AddTweets.new([registered_tag]) }
+          it 'RegisteredTag#add_tweetsを実行しない' do
             create(:tweet, :tweeted_yesterday, registered_tag: registered_tag)
             registered_tag.fetch_tweets_data!
             expect(registered_tag).not_to receive(:add_tweets)
@@ -59,7 +59,7 @@ RSpec.describe TwitterAPI do
         end
         context '前日のツイートがなかったとき',
           vcr: { cassette_name: 'twitter_api/everyday_search/前日のツイートがなかったとき' } do
-          xit 'Rails.logger.infoを実行しない' do
+          it 'Rails.logger.infoを実行しない' do
             expect(Rails.logger).not_to receive(:info)
             add_tweets.call
           end
@@ -70,7 +70,8 @@ RSpec.describe TwitterAPI do
         let!(:registered_tag) {
           create(:registered_tag, user: user, tag: create(:tag, name: 'ポートフォリオ進捗'))
         }
-        xit 'RegisteredTag#create_tweets!を実行する' do
+        let(:add_tweets) { TwitterAPI::AddTweets.new([registered_tag]) }
+        it 'RegisteredTag#create_tweets!を実行する' do
           expect(registered_tag).to receive(:create_tweets!)
           add_tweets.call
         end


### PR DESCRIPTION
## 概要
close #31
#71

## 原因

モックの主体となるオブジェクトが同一でなかったので通らなかった。
外部からオブジェクトを代入できるようにして対応。

## キーワード

- オブジェクトとしての同一性
https://techracho.bpsinc.jp/hachi8833/2018_07_04/58707

- 依存性注入（Dependency Injection）
https://qiita.com/hshimo/items/1136087e1c6e5c5b0d9f
https://scrapbox.io/masakis-note/Ruby%E3%81%AB%E3%81%8A%E3%81%91%E3%82%8B%E4%BE%9D%E5%AD%98%E6%80%A7%E3%81%AE%E6%B3%A8%E5%85%A5
https://techracho.bpsinc.jp/hachi8833/2019_05_09/62314