### PR TITLE
エラーなどの修正

### DIFF
--- a/app/controllers/api/v1/registered_tags/persistences_controller.rb
+++ b/app/controllers/api/v1/registered_tags/persistences_controller.rb
@@ -1,9 +1,8 @@
-require 'pagy/extras/array'
-
 class Api::V1::RegisteredTags::PersistencesController < Api::V1::BaseController
   def index
-    registered_tags = RegisteredTag.opened.includes(:user, :tag).persistence_sort
-    @pagy, registered_tags = pagy_array(registered_tags)
+    registered_tags = RegisteredTag.includes(:user, :tag).opened.have_tweets
+    @pagy, registered_tags = pagy(registered_tags)
+    registered_tags = registered_tags.persistence_sort
     render json: registered_tags
   end
 end

--- a/app/controllers/api/v1/user_sessions_controller.rb
+++ b/app/controllers/api/v1/user_sessions_controller.rb
@@ -8,6 +8,6 @@ class Api::V1::UserSessionsController < Api::V1::BaseController
   def guest_login
     user = User.find_by!(role: :guest)
     auto_login(user)
-    render json: user, status: 200
+    render json: user, status: :ok
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,6 +2,6 @@ class StaticPagesController < ApplicationController
   def top; end
 
   def routing_error
-    render :top, status: :not_found
+    render :top, formats: :html, status: :not_found
   end
 end

--- a/app/dashboards/authentication_dashboard.rb
+++ b/app/dashboards/authentication_dashboard.rb
@@ -10,8 +10,10 @@ class AuthenticationDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     user: Field::BelongsTo,
     id: Field::Number,
-    provider: Field::String,
+    provider: Field::Select.with_options(collection: %i[twitter]),
     uid: Field::String,
+    access_token: Field::String,
+    access_token_secret: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -26,6 +28,8 @@ class AuthenticationDashboard < Administrate::BaseDashboard
     provider
     user
     uid
+    access_token
+    access_token_secret
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -46,6 +50,8 @@ class AuthenticationDashboard < Administrate::BaseDashboard
     user
     provider
     uid
+    access_token
+    access_token_secret
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -8,7 +8,7 @@ class UserDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    authentications: Field::HasMany,
+    authentication: Field::HasOne,
     registered_tags: Field::HasMany,
     tags: Field::HasMany,
     id: Field::Number,
@@ -55,7 +55,7 @@ class UserDashboard < Administrate::BaseDashboard
     updated_at
     registered_tags
     tags
-    authentications
+    authentication
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -69,7 +69,7 @@ class UserDashboard < Administrate::BaseDashboard
     privacy
     role
     avatar_url
-    authentications
+    authentication
     tags
   ].freeze
 

--- a/app/javascript/components/Profile.vue
+++ b/app/javascript/components/Profile.vue
@@ -3,13 +3,30 @@
     <v-card class="mx-auto" outlined>
       <v-container row>
         <v-col cols="12" md="9">
-          <!-- プロフィール -->
+          <!-- Twitter情報 -->
+          <v-list-item>
+            <v-list-item-avatar color="grey" size="60">
+              <v-img :src="user.avatarUrl" />
+            </v-list-item-avatar>
+            <v-list-item-content>
+              <v-list-item-title class="title">
+                {{ user.name }}
+              </v-list-item-title>
+              <v-list-item-subtitle
+                >@{{ user.screenName }}
+                <v-btn icon color="blue" :href="twitterUrl">
+                  <v-icon>mdi-twitter</v-icon>
+                </v-btn>
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+          <!-- プロフィール詳細部分 -->
           <profile-view
             v-if="!isEditing"
             :user="user"
             @push-edit="isEditing = true"
           />
-          <!-- ユーザー編集 -->
+          <!-- ユーザー編集部分 -->
           <profile-edit
             v-if="isEditing"
             :user="user"

--- a/app/javascript/components/ProfileEdit.vue
+++ b/app/javascript/components/ProfileEdit.vue
@@ -1,19 +1,5 @@
 <template>
   <ValidationObserver ref="observer" v-slot="{ invalid }">
-    <v-list-item>
-      <v-list-item-avatar color="grey" size="60">
-        <v-img :src="user.avatarUrl" />
-      </v-list-item-avatar>
-      <v-list-item-content>
-        <v-list-item-title class="title">
-          {{ user.name }}
-          <v-btn icon color="blue" :href="twitterUrl">
-            <v-icon>mdi-twitter</v-icon>
-          </v-btn>
-        </v-list-item-title>
-        <v-list-item-subtitle>@{{ user.screenName }}</v-list-item-subtitle>
-      </v-list-item-content>
-    </v-list-item>
     <v-card-text class="my-0">
       <div class="body-1">
         <ValidationProvider
@@ -25,6 +11,7 @@
             v-model="user.description"
             outlined
             :counter="300"
+            messages="この変更はTwitterには反映されません"
             :error-messages="errors"
             rows="5"
             label="プロフィール"

--- a/app/javascript/components/ProfileView.vue
+++ b/app/javascript/components/ProfileView.vue
@@ -1,21 +1,5 @@
 <template>
   <div>
-    <v-list-item>
-      <v-list-item-avatar color="grey" size="60">
-        <v-img :src="user.avatarUrl" />
-      </v-list-item-avatar>
-      <v-list-item-content>
-        <v-list-item-title class="title">
-          {{ user.name }}
-        </v-list-item-title>
-        <v-list-item-subtitle
-          >@{{ user.screenName }}
-          <v-btn icon color="blue" :href="twitterUrl">
-            <v-icon>mdi-twitter</v-icon>
-          </v-btn>
-        </v-list-item-subtitle>
-      </v-list-item-content>
-    </v-list-item>
     <v-card-text>
       <div
         class="body-1"

--- a/app/javascript/components/ProfileView.vue
+++ b/app/javascript/components/ProfileView.vue
@@ -7,11 +7,13 @@
       <v-list-item-content>
         <v-list-item-title class="title">
           {{ user.name }}
+        </v-list-item-title>
+        <v-list-item-subtitle
+          >@{{ user.screenName }}
           <v-btn icon color="blue" :href="twitterUrl">
             <v-icon>mdi-twitter</v-icon>
           </v-btn>
-        </v-list-item-title>
-        <v-list-item-subtitle>@{{ user.screenName }}</v-list-item-subtitle>
+        </v-list-item-subtitle>
       </v-list-item-content>
     </v-list-item>
     <v-card-text>
@@ -30,14 +32,16 @@
         color="primary"
         class="ma-2"
         :to="{ name: 'user', params: { userUuid: user.uuid } }"
-      >ユーザーページを見る</v-btn>
+        >ユーザーページを見る</v-btn
+      >
       <v-btn
         depressed
         color="primary"
         class="ma-2"
         href="/admin"
         v-if="user.role === '管理ユーザー'"
-      >管理ページ</v-btn>
+        >管理ページ</v-btn
+      >
     </div>
   </div>
 </template>

--- a/app/javascript/components/TagStatusEdit.vue
+++ b/app/javascript/components/TagStatusEdit.vue
@@ -23,7 +23,9 @@
           />
           <validation-provider
             v-slot="{ errors }"
-            :rules="`${isRemind ? 'remindDay|maxRemindDay|minRemindDay' : ''}`"
+            :rules="
+              `${isRemind ? 'remindDayFormat|maxRemindDay|minRemindDay' : ''}`
+            "
           >
             <v-text-field
               v-show="isRemind"
@@ -39,7 +41,9 @@
       </v-list-item>
     </v-container>
     <v-list-item>
-      <v-btn class="ma-2" outlined color="primary" @click="$emit('push-cancel')">キャンセル</v-btn>
+      <v-btn class="ma-2" outlined color="primary" @click="$emit('push-cancel')"
+        >キャンセル</v-btn
+      >
       <v-btn
         class="ma-2"
         depressed

--- a/app/javascript/components/TheRegisterTagDialog.vue
+++ b/app/javascript/components/TheRegisterTagDialog.vue
@@ -13,7 +13,7 @@
                   ref="provider"
                   v-slot="{ errors }"
                   name="ハッシュタグ"
-                  rules="required"
+                  rules="required|tagNameFormat"
                 >
                   <v-text-field
                     v-model="tagName"

--- a/app/javascript/components/TheRegisterTagDialog.vue
+++ b/app/javascript/components/TheRegisterTagDialog.vue
@@ -27,6 +27,9 @@
                   </v-text-field>
                 </ValidationProvider>
               </v-form>
+              <p class="ml-md-10 mt-5">
+                登録時に直近1週間のツイートを取得します。<br />ハッシュタグは3つまで登録できます。
+              </p>
             </v-container>
           </v-card-text>
           <v-card-actions>

--- a/app/javascript/components/TheRegisterTagDialog.vue
+++ b/app/javascript/components/TheRegisterTagDialog.vue
@@ -95,13 +95,15 @@ export default {
           })
           this.resetForm()
         } catch (error) {
+          const unprocessableEntityStatus = 422
+          const tooManyRequestsStatus = 429
           switch (error.response.status) {
-            case 422: {
+            case unprocessableEntityStatus: {
               const errorMessage = error.response.data.error.messages[0]
               this.$refs.provider.errors.push(errorMessage)
               break
             }
-            case 429: {
+            case tooManyRequestsStatus: {
               const errorMessage = error.response.data.error.messages[0]
               this.$refs.provider.errors.push(errorMessage)
               break

--- a/app/javascript/components/TheTagWrapper.vue
+++ b/app/javascript/components/TheTagWrapper.vue
@@ -1,17 +1,9 @@
 <template>
   <div>
     <!-- タブ -->
-    <the-tab
-      :registered-tags="registeredTags"
-      @select-tab="firstRead"
-      @create-tag="firstRead"
-    />
+    <the-tab :registered-tags="registeredTags" @select-tab="firstRead" @create-tag="firstRead" />
     <!-- カレンダー -->
-    <the-calendar
-      ref="calendar"
-      :tweet-dates="tweetDates"
-      @input-date="fetchDateTweets"
-    />
+    <the-calendar ref="calendar" :tweet-dates="tweetDates" @input-date="fetchDateTweets" />
     <v-container class="main-content d-flex flex-row-reverse pt-0 px-0" row>
       <!-- ハッシュタグの情報 -->
       <v-col cols="12" md="4">
@@ -103,7 +95,7 @@ export default {
       this.fetchTweetDates()
       this.fetchTweetsData()
       await this.fetchTagData()
-      document.title = `#${this.registeredTag.tag.name} | Hashlog`
+      document.title = `#${this.registeredTag.tag.name} - Hashlog`
     },
     async fetchTagData() {
       const registeredTagRes = await this.$axios.get(this.registeredTagUrl)

--- a/app/javascript/components/TheTagWrapper.vue
+++ b/app/javascript/components/TheTagWrapper.vue
@@ -1,9 +1,17 @@
 <template>
   <div>
     <!-- タブ -->
-    <the-tab :registered-tags="registeredTags" @select-tab="firstRead" @create-tag="firstRead" />
+    <the-tab
+      :registered-tags="registeredTags"
+      @select-tab="firstRead"
+      @create-tag="firstRead"
+    />
     <!-- カレンダー -->
-    <the-calendar ref="calendar" :tweet-dates="tweetDates" @input-date="fetchDateTweets" />
+    <the-calendar
+      ref="calendar"
+      :tweet-dates="tweetDates"
+      @input-date="fetchDateTweets"
+    />
     <v-container class="main-content d-flex flex-row-reverse pt-0 px-0" row>
       <!-- ハッシュタグの情報 -->
       <v-col cols="12" md="4">
@@ -135,7 +143,7 @@ export default {
       this.page.requestUrl = response.headers["request-url"]
     },
     async changePaginationPage(val) {
-      this.$toTop(0)
+      this.$toTop()
       const res = await this.$axios.get(this.paginationUrl(val))
       const { tweets } = res.data
       this.tweets = tweets

--- a/app/javascript/pages/MyTag.vue
+++ b/app/javascript/pages/MyTag.vue
@@ -41,7 +41,7 @@ export default {
     this.fetchRegisteredTagsData()
   },
   methods: {
-    // タプ用ユーザーの全てのタグ
+    // タブ用ユーザーの全てのタグ
     async fetchRegisteredTagsData() {
       const registeredTagsRes = await this.$axios.get(
         "/api/v1/users/current/registered_tags"

--- a/app/javascript/pages/Mypage.vue
+++ b/app/javascript/pages/Mypage.vue
@@ -46,7 +46,7 @@ export default {
       })
       document.cookie = "logged_in=;path=/;max-age=0;"
     }
-    document.title = "マイページ | Hashlog"
+    document.title = "マイページ - Hashlog"
     this.fetchRegisteredTagsData(this.currentUser)
   },
   methods: {

--- a/app/javascript/pages/NotFound.vue
+++ b/app/javascript/pages/NotFound.vue
@@ -18,7 +18,7 @@
 <script>
 export default {
   mounted() {
-    document.title = "ページが見つかりません | Hashlog"
+    document.title = "ページが見つかりません - Hashlog"
   }
 }
 </script>

--- a/app/javascript/pages/TagRanking.vue
+++ b/app/javascript/pages/TagRanking.vue
@@ -13,7 +13,7 @@
           }"
         >
           <v-list-item-avatar>
-            <v-icon>{{ index + 1 }}</v-icon>
+            <v-icon>{{ rank(index) }}</v-icon>
           </v-list-item-avatar>
 
           <v-list-item-avatar color="grey" size="50" class="mr-7">
@@ -26,9 +26,7 @@
           </v-list-item-content>
 
           <v-list-item-action>{{ tag.tweetRate }}%</v-list-item-action>
-          <v-list-item-action class="d-none d-md-flex"
-            >（{{ tag.tweetedDayCount }}日）</v-list-item-action
-          >
+          <v-list-item-action class="d-none d-md-flex">（{{ tag.tweetedDayCount }}日）</v-list-item-action>
         </v-list-item>
       </v-list>
     </v-card>
@@ -61,6 +59,10 @@ export default {
     document.title = "継続率ランキング | Hashlog"
   },
   methods: {
+    rank(index) {
+      const increase = (this.page.currentPage - 1) * 20
+      return increase + index + 1
+    },
     async fetchRegisteredTagsData() {
       const registeredTagsRes = await this.$axios.get(
         "/api/v1/registered_tags/persistences"

--- a/app/javascript/pages/TagRanking.vue
+++ b/app/javascript/pages/TagRanking.vue
@@ -56,7 +56,7 @@ export default {
   },
   mounted() {
     this.fetchRegisteredTagsData()
-    document.title = "継続率ランキング | Hashlog"
+    document.title = "継続率ランキング - Hashlog"
   },
   methods: {
     rank(index) {

--- a/app/javascript/pages/TagRanking.vue
+++ b/app/javascript/pages/TagRanking.vue
@@ -26,7 +26,9 @@
           </v-list-item-content>
 
           <v-list-item-action>{{ tag.tweetRate }}%</v-list-item-action>
-          <v-list-item-action class="d-none d-md-flex">（{{ tag.tweetedDayCount }}日）</v-list-item-action>
+          <v-list-item-action class="d-none d-md-flex"
+            >（{{ tag.tweetedDayCount }}日）</v-list-item-action
+          >
         </v-list-item>
       </v-list>
     </v-card>
@@ -60,8 +62,10 @@ export default {
   },
   methods: {
     rank(index) {
-      const increase = (this.page.currentPage - 1) * 20
-      return increase + index + 1
+      const tagCountPerPage = 20
+      const increase = (this.page.currentPage - 1) * tagCountPerPage
+      const rank = increase + index + 1
+      return rank
     },
     async fetchRegisteredTagsData() {
       const registeredTagsRes = await this.$axios.get(
@@ -77,7 +81,7 @@ export default {
       this.page.requestUrl = response.headers["request-url"]
     },
     async changePaginationPage(val) {
-      this.$toTop(0)
+      this.$toTop()
       const res = await this.$axios.get(`${this.page.requestUrl}?page=${val}`)
       const { registeredTags } = res.data
       this.registeredTags = registeredTags

--- a/app/javascript/pages/Terms.vue
+++ b/app/javascript/pages/Terms.vue
@@ -6,9 +6,11 @@
 import theTerms from "../components/TheTerms"
 
 export default {
-  title: "利用規約",
   components: {
     theTerms
+  },
+  mounted() {
+    document.title = "利用規約 - Hashlog"
   }
 }
 </script>

--- a/app/javascript/pages/User.vue
+++ b/app/javascript/pages/User.vue
@@ -40,7 +40,7 @@ export default {
   methods: {
     async firstRead() {
       await this.fetchUserData()
-      document.title = `${this.user.name}のユーザーページ | Hashlog`
+      document.title = `${this.user.name}のユーザーページ - Hashlog`
     },
     async fetchUserData() {
       const { userUuid } = this.$route.params

--- a/app/javascript/plugins/axios.js
+++ b/app/javascript/plugins/axios.js
@@ -18,16 +18,21 @@ http.interceptors.request.use(request => {
 })
 
 const errorMessage = error => {
+  const unauthorized = 402
+  const forbidden = 403
+  const notFound = 404
+  const unprocessableEntity = 422
+  const tooManyRequests = 429
   switch (error.response.status) {
-    case 401:
+    case unauthorized:
       return "ログインしてください"
-    case 403:
+    case forbidden:
       return "アクセスが許可されていません"
-    case 404:
+    case notFound:
       return "リソースが見つかりません"
-    case 422: // バリデーションメッセージは個別で処理を行う
+    case unprocessableEntity: // バリデーションメッセージは個別で処理を行う
       return null
-    case 429: // フォームにエラーメッセージを表示する（同上）
+    case tooManyRequests: // フォームにエラーメッセージを表示する（同上）
       return null
     default:
       return "予期せぬエラーが発生しました"

--- a/app/javascript/plugins/custom-plugins.js
+++ b/app/javascript/plugins/custom-plugins.js
@@ -3,7 +3,8 @@ import goTo from "vuetify/es5/services/goto"
 export default {
   methods: {
     $toTop() {
-      goTo(0)
+      const pageTop = 0
+      goTo(pageTop)
     }
   }
 }

--- a/app/javascript/plugins/vee-validate.js
+++ b/app/javascript/plugins/vee-validate.js
@@ -5,13 +5,25 @@ extend("required", {
   ...required,
   message: "{_field_}を入力してください"
 })
+
 extend("max", {
   ...max,
   message: "{_field_}は最大{length}文字です"
 })
 
-const filter = remindDay => {
-  const stringRemindDay = String(remindDay)
+const filterTagName = value => value.replace(/^#+/, "")
+
+extend("tagNameFormat", {
+  validate(value) {
+    return filterTagName(value).match(
+      /^[Ａ-Ｚａ-ｚA-Za-z一-龠々0-9０-９ぁ-ヶｦ-ﾟー゛゜_]+$/
+    )
+  },
+  message: "入力形式が不適です"
+})
+
+const filterRemindDay = value => {
+  const stringRemindDay = String(value)
   if (stringRemindDay === null) {
     return null
   }
@@ -23,16 +35,16 @@ const filter = remindDay => {
   return Number(result)
 }
 
-extend("remindDay", {
+extend("remindDayFormat", {
   validate(value) {
-    return !isNaN(filter(value))
+    return !isNaN(filterRemindDay(value))
   },
   message: "入力形式が不適です"
 })
 
 extend("maxRemindDay", {
   validate(value) {
-    if (filter(value) > 30) {
+    if (filterRemindDay(value) > 30) {
       return false
     }
     return true
@@ -42,7 +54,7 @@ extend("maxRemindDay", {
 
 extend("minRemindDay", {
   validate(value) {
-    if (filter(value) < 1) {
+    if (filterRemindDay(value) < 1) {
       return false
     }
     return true

--- a/app/javascript/plugins/vee-validate.js
+++ b/app/javascript/plugins/vee-validate.js
@@ -44,7 +44,8 @@ extend("remindDayFormat", {
 
 extend("maxRemindDay", {
   validate(value) {
-    if (filterRemindDay(value) > 30) {
+    const maxDayCount = 30
+    if (filterRemindDay(value) > maxDayCount) {
       return false
     }
     return true
@@ -54,7 +55,8 @@ extend("maxRemindDay", {
 
 extend("minRemindDay", {
   validate(value) {
-    if (filterRemindDay(value) < 1) {
+    const minDayCount
+    if (filterRemindDay(value) < minDayCount) {
       return false
     }
     return true

--- a/app/javascript/plugins/vee-validate.js
+++ b/app/javascript/plugins/vee-validate.js
@@ -55,7 +55,7 @@ extend("maxRemindDay", {
 
 extend("minRemindDay", {
   validate(value) {
-    const minDayCount
+    const minDayCount = 1
     if (filterRemindDay(value) < minDayCount) {
       return false
     }

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -1,4 +1,15 @@
 class RegisteredTag < ApplicationRecord
+  DAY_COUNT_MONTH = 30
+  PUBLISDED = 0
+  CLOSED = 1
+  LIMITED = 2
+  NONE = 0
+  FULL = 1
+  FULL_PER = 100
+  USER_REGISTERED_TAGS_COUNT = 3
+  [DAY_COUNT_MONTH, PUBLISDED, CLOSED, LIMITED,
+   NONE, FULL, FULL_PER, USER_REGISTERED_TAGS_COUNT].each(&:freeze)
+
   before_validation :filter_remind_day
 
   has_many :tweets, dependent: :destroy
@@ -6,15 +17,16 @@ class RegisteredTag < ApplicationRecord
   belongs_to :tag
 
   validates :privacy, presence: true
-  validates :remind_day, numericality: { only_integer: true, less_than_or_equal_to: 30 }
+  validates :remind_day, numericality: { only_integer: true,
+                                         less_than_or_equal_to: DAY_COUNT_MONTH }
   validates :tag_id, uniqueness: { scope: :user_id, message: 'は既に登録しています' }
   validate :user_registered_tags_count_validate, on: :create
 
-  enum privacy: { published: 0, closed: 1, limited: 2 }
+  enum privacy: { published: PUBLISDED, closed: CLOSED, limited: LIMITED }
 
   scope :asc, -> { order(created_at: :asc) }
   scope :desc, -> { order(created_at: :desc) }
-  scope :opened, -> { published.joins(:user).where('users.privacy = ?', 0) }
+  scope :opened, -> { published.joins(:user).where('users.privacy = ?', PUBLISDED) }
   scope :have_tweets, -> { where('first_tweeted_at < ?', Time.now) }
 
   def self.persistence_sort
@@ -30,20 +42,20 @@ class RegisteredTag < ApplicationRecord
   end
 
   def day_from_last_tweet
-    last_tweeted_at.nil? ? 0 : (Date.today - last_tweeted_at.to_date).to_i
+    last_tweeted_at.nil? ? NONE : (Date.today - last_tweeted_at.to_date).to_i
   end
 
   def day_from_first_tweet
-    first_tweeted_at.nil? ? 0 : (Date.today - first_tweeted_at.to_date).to_i + 1
+    first_tweeted_at.nil? ? NONE : (Date.today - first_tweeted_at.to_date).to_i + 1
   end
 
   def tweet_rate
-    return 0 if first_tweeted_at.nil?
-    return 1 if (day_from_first_tweet - day_from_last_tweet).zero?
+    return NONE if first_tweeted_at.nil?
+    return FULL if (day_from_first_tweet - day_from_last_tweet).zero?
 
     # 今日のデータがない場合は昨日時点までのデータで計算する
     denominator = day_from_last_tweet.zero? ? day_from_first_tweet : day_from_first_tweet - 1
-    (tweeted_day_count.to_f / denominator * 100).round(1)
+    (tweeted_day_count.to_f / denominator * FULL_PER).round(1)
   end
 
   def create_tweets!(type = 'standard')
@@ -67,10 +79,12 @@ class RegisteredTag < ApplicationRecord
   private
 
   def filter_remind_day
-    self.remind_day = 0 if remind_day.nil?
+    self.remind_day = NONE if remind_day.nil?
   end
 
   def user_registered_tags_count_validate
-    errors.add(:base, '登録できるハッシュタグは3つまでです') if user&.registered_tags&.count.to_d >= 3
+    if user&.registered_tags&.count.to_d >= USER_REGISTERED_TAGS_COUNT
+      errors.add(:base, '登録できるハッシュタグは3つまでです')
+    end
   end
 end

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -18,7 +18,7 @@ class RegisteredTag < ApplicationRecord
   scope :have_tweets, -> { where('first_tweeted_at < ?', Time.now) }
 
   def self.persistence_sort
-    all.sort_by(&:tweet_rate).reverse
+    all.sort_by { |tag| [tag.tweet_rate, tag.tweeted_day_count] }.reverse
   end
 
   def last_tweeted_at
@@ -50,7 +50,7 @@ class RegisteredTag < ApplicationRecord
     client = TwitterAPI::Search.new(user, tag.name)
     client.tweets_data(type).each do |oembed, tweeted_at, tweet_id|
       tweets.create!(oembed: oembed, tweeted_at: tweeted_at, tweet_id: tweet_id)
-    end
+    end.any? && fetch_tweets_data!
   end
 
   def add_tweets(since_id)

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -15,6 +15,7 @@ class RegisteredTag < ApplicationRecord
   scope :asc, -> { order(created_at: :asc) }
   scope :desc, -> { order(created_at: :desc) }
   scope :opened, -> { published.joins(:user).where('users.privacy = ?', 0) }
+  scope :have_tweets, -> { where('first_tweeted_at < ?', Time.now) }
 
   def self.persistence_sort
     all.sort_by(&:tweet_rate).reverse

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -83,8 +83,8 @@ class RegisteredTag < ApplicationRecord
   end
 
   def user_registered_tags_count_validate
-    if user&.registered_tags&.count.to_d >= USER_REGISTERED_TAGS_COUNT
-      errors.add(:base, '登録できるハッシュタグは3つまでです')
-    end
+    return unless user&.registered_tags&.count.to_d >= USER_REGISTERED_TAGS_COUNT
+
+    errors.add(:base, '登録できるハッシュタグは3つまでです')
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,6 @@
 class Tag < ApplicationRecord
+  before_validation :remove_first_hashtag_mark
+
   has_many :registered_tags, dependent: :restrict_with_error
   has_many :users, through: :registered_tags
 
@@ -6,4 +8,10 @@ class Tag < ApplicationRecord
 
   # TODO: 警告を直す
   scope :popular, -> { joins(:registered_tags).group(:tag_id).order('count(user_id) DESC') }
+
+  private
+
+  def remove_first_hashtag_mark
+    name&.gsub!(/^#+/, '')
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,6 +4,7 @@ class Tag < ApplicationRecord
   has_many :registered_tags, dependent: :restrict_with_error
   has_many :users, through: :registered_tags
 
+  validates :name, format: { with: /\A[Ａ-Ｚａ-ｚA-Za-z一-龠々0-9０-９ぁ-ヶｦ-ﾟー゛゜_]+\Z/, message: 'が不適な形式です' }
   validates :name, presence: true, uniqueness: true, length: { maximum: 100 }
 
   # TODO: 警告を直す
@@ -13,5 +14,7 @@ class Tag < ApplicationRecord
 
   def remove_first_hashtag_mark
     name&.gsub!(/^#+/, '')
+    # 数字_゛゜だけの場合はバリデーションで弾くために、'@'に置き換える。ゴリ押しっぽいけど…
+    name&.gsub!(/\A[\d０-９゛゜_]+\Z/, '@')
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,7 +4,7 @@ class Tag < ApplicationRecord
   has_many :registered_tags, dependent: :restrict_with_error
   has_many :users, through: :registered_tags
 
-  validates :name, format: { with: /\A[Ａ-Ｚａ-ｚA-Za-z一-龠々0-9０-９ぁ-ヶｦ-ﾟー゛゜_]+\Z/, message: 'が不適な形式です' }
+  validates :name, format: { with: /\A[Ａ-Ｚａ-ｚA-Za-z一-龠々0-9０-９ぁ-ヶｦ-ﾟー゛゜_]+\Z/, message: 'の入力形式が不適です' }
   validates :name, presence: true, uniqueness: true, length: { maximum: 100 }
 
   # TODO: 警告を直す

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,7 +4,8 @@ class Tag < ApplicationRecord
   has_many :registered_tags, dependent: :restrict_with_error
   has_many :users, through: :registered_tags
 
-  validates :name, format: { with: /\A[Ａ-Ｚａ-ｚA-Za-z一-龠々0-9０-９ぁ-ヶｦ-ﾟー゛゜_]+\Z/, message: 'の入力形式が不適です' }
+  validates :name, format: { with: /\A[Ａ-Ｚａ-ｚA-Za-z一-龠々0-9０-９ぁ-ヶｦ-ﾟー゛゜_]+\Z/,
+                             message: 'の入力形式が不適です' }
   validates :name, presence: true, uniqueness: true, length: { maximum: 100 }
 
   # TODO: 警告を直す

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,6 @@ class User < ApplicationRecord
       registered_tag = registered_tags.build(tag_id: tag.id)
       registered_tag.save!
       registered_tag.create_tweets!
-      registered_tag.fetch_tweets_data!
       true
     rescue ActiveRecord::RecordInvalid
       tag.errors.messages.merge!(registered_tag.errors.messages) if tag.valid?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,11 @@
 class User < ApplicationRecord
+  PUBLISHED = 0
+  CLOSED = 1
+  ADMIN = 0
+  GENARAL = 1
+  GUEST = 2
+  [PUBLISHED, CLOSED, ADMIN, GENARAL, GUEST].each(&:freeze)
+
   before_create :set_uuid
   before_save :replace_user_data
 
@@ -15,8 +22,8 @@ class User < ApplicationRecord
   validates :privacy, presence: true
   validates :role, presence: true
 
-  enum privacy: { published: 0, closed: 1 }
-  enum role: { admin: 0, general: 1, guest: 2 }
+  enum privacy: { published: PUBLISHED, closed: CLOSED }
+  enum role: { admin: ADMIN, general: GENARAL, guest: GUEST }
 
   # tagからregistered_tagを返す
   def registered_tag(tag)

--- a/app/services/twitter_api.rb
+++ b/app/services/twitter_api.rb
@@ -9,7 +9,7 @@ module TwitterAPI
     end
 
     def call
-      registered_tags.each do |tag|
+      registered_tags.find_each do |tag|
         send_tweet(tag) if tag.remind_day.positive? && tag.remind_day < tag.day_from_last_tweet
       end
     end
@@ -43,7 +43,7 @@ module TwitterAPI
     end
 
     def call
-      registered_tags.each do |r_tag|
+      registered_tags.find_each do |r_tag|
         last_tweet = r_tag.tweets.latest
         r_tag.create_tweets! && next unless last_tweet
 

--- a/app/services/twitter_api.rb
+++ b/app/services/twitter_api.rb
@@ -1,4 +1,7 @@
 module TwitterAPI
+  MAX_RESULTS = 100
+  MAX_RESULTS.freeze
+
   class RemindReply
     include TwitterAPIClient
     attr_reader :notify_logs
@@ -9,7 +12,7 @@ module TwitterAPI
     end
 
     def call
-      registered_tags.find_each do |tag|
+      registered_tags.each do |tag|
         send_tweet(tag) if tag.remind_day.positive? && tag.remind_day < tag.day_from_last_tweet
       end
     end
@@ -37,15 +40,18 @@ module TwitterAPI
     include TwitterAPIClient
     attr_reader :notify_logs
 
-    def initialize
-      @registered_tags = RegisteredTag.all.includes(:user, :tag)
+    def initialize(registered_tags = RegisteredTag.all.includes(:user, :tag))
+      @registered_tags = registered_tags
       @notify_logs = []
     end
 
     def call
-      registered_tags.find_each do |r_tag|
+      registered_tags.each do |r_tag|
         last_tweet = r_tag.tweets.latest
-        r_tag.create_tweets! && next unless last_tweet
+        unless last_tweet
+          r_tag.create_tweets!
+          next
+        end
 
         next if last_tweet.tweeted_at > Time.current.prev_day.beginning_of_day
 
@@ -82,9 +88,9 @@ module TwitterAPI
       when 'everyday'
         everyday_search
       end
-      client(user).oembeds(tweet_ids, omit_script: true, hide_thread: true, lang: :ja)
-                  .take(100)
-                  .map do |oembed|
+      client.oembeds(tweet_ids, omit_script: true, hide_thread: true, lang: :ja)
+            .take(MAX_RESULTS)
+            .map do |oembed|
         oembed.html =~ %r{\" dir=\"ltr\">(.+)</p>}
         $+
       end.zip(tweeted_ats, tweet_ids)
@@ -96,8 +102,8 @@ module TwitterAPI
 
     def standard_search
       @standard_search ||= begin
-        client(user).search("##{tag_name} from:#{user.screen_name} exclude:retweets",
-                            result_type: 'recent', count: 100).take(100).each do |result|
+        client.search("##{tag_name} from:#{user.screen_name} exclude:retweets",
+                      result_type: 'recent', count: MAX_RESULTS).take(MAX_RESULTS).each do |result|
           tweeted_ats << result.created_at
           tweet_ids << result.id
         end
@@ -106,9 +112,9 @@ module TwitterAPI
 
     def premium_search
       @premium_search ||= begin
-        client(user).premium_search("##{tag_name} from:#{user.screen_name}",
-                                    { maxResults: 100 },
-                                    { product: '30day' }).take(100).each do |result|
+        client.premium_search("##{tag_name} from:#{user.screen_name}",
+                              { maxResults: MAX_RESULTS },
+                              { product: '30day' }).take(MAX_RESULTS).each do |result|
           next if result.retweeted_status.present?
 
           tweeted_ats << result.created_at
@@ -119,8 +125,8 @@ module TwitterAPI
 
     def everyday_search
       @everyday_search ||= begin
-        client(user).search("##{tag_name} from:#{user.screen_name} exclude:retweets",
-                            result_type: 'recent', since_id: since_id).take(100).each do |result|
+        client.search("##{tag_name} from:#{user.screen_name} exclude:retweets",
+                      result_type: 'recent', since_id: since_id).take(MAX_RESULTS).each do |result|
           tweeted_ats << result.created_at
           tweet_ids << result.id
         end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
 
     <meta property="og:url" content="https://hashlog.work" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Hashlog（ハッシュログ） - あなたの継続を可視化できる、Twitter連携型 学習記録サービス" />
+    <meta property="og:title" content="Hashlog（ハッシュログ） - あなたの継続を可視化できる Twitter連携型 学習記録サービス" />
     <meta property="og:description" content="Hashlogは、ハッシュタグを登録するだけであなたの継続を可視化する、Twitter連携型 学習記録サービスです。学習の振り返り、頑張りの可視化、ツイートのポートフォリオ化ができます。" />
     <meta property="og:site_name" content="Hashlog（ハッシュログ）" />
     <meta property="og:image" content="https://hashlog.work/img/ogp.png" />

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]

--- a/db/fixtures/admin_user.rb
+++ b/db/fixtures/admin_user.rb
@@ -11,8 +11,8 @@ User.seed_once(
 
 Authentication.seed_once(
   user_id: 1,
-  provider: "twitter",
-  uid: "1242379749650907137"
+  provider: 'twitter',
+  uid: '1242379749650907137'
 )
 
 User.seed_once(
@@ -27,6 +27,6 @@ User.seed_once(
 )
 Authentication.seed_once(
   user_id: 2,
-  provider: "twitter",
-  uid: "1048451188209770497"
+  provider: 'twitter',
+  uid: '1048451188209770497'
 )

--- a/public/404.html
+++ b/public/404.html
@@ -1,67 +1,83 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <head>
+    <title>ページが見つかりません - Hashlog</title>
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900"
+    />
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css"
+    />
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui"
+    />
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+    <style>
+      .theme--light.v-application {
+        background-color: #e9f1f6;
+      }
+      .theme--light.v-btn:not(.v-btn--flat):not(.v-btn--text):not(.v-btn--outlined) {
+        background-color: #0079b5;
+      }
+    </style>
+  </head>
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+  <body>
+    <div id="app">
+      <div
+        data-app="true"
+        class="v-application v-application--is-ltr theme--light"
+        id="app"
+      >
+        <div class="v-application--wrap">
+          <main class="v-content" style="padding: 20px 0px;" data-booted="true">
+            <div class="v-content__wrap">
+              <div class="container">
+                <div class="content pt-10 pb-5">
+                  <h1 class="display-3 font-weight-thin">
+                    404 NotFound
+                  </h1>
+                  <div class="mt-10 mb-10">
+                    <p>
+                      お探しのページが見つかりませんでした。
+                    </p>
+                    <p>
+                      一時的にアクセスができない状況にあるか
+                      <br
+                        class="d-flex d-sm-none"
+                      />移動もしくは削除された可能性があります。
+                    </p>
+                    <p>
+                      URLにお間違いがないか再度ご確認ください。
+                    </p>
+                  </div>
+                  <a
+                    href="https://hashlog.work"
+                    class="v-btn--active v-btn v-btn--depressed v-btn--router theme--light v-size--default primary"
+                    ><span class="v-btn__content"
+                      ><i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--left mdi mdi-exit-run theme--light"
+                      ></i
+                      >トップページに戻る
+                    </span></a
+                  >
+                </div>
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -1,67 +1,98 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>The change you wanted was rejected (422)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <head>
+    <title>一時的なエラーが発生しました - Hashlog</title>
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900"
+    />
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css"
+    />
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui"
+    />
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+    <style>
+      .theme--light.v-application {
+        background-color: #e9f1f6;
+      }
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+      .theme--light.v-btn:not(.v-btn--flat):not(.v-btn--text):not(.v-btn--outlined) {
+        background-color: #0079b5;
+      }
+      a.link-text {
+        color: #0079b5;
+        text-decoration: underline;
+      }
+      a.link-text:hover {
+        opacity: 0.7;
+      }
+    </style>
+  </head>
 
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+  <body>
+    <div id="app">
+      <div
+        data-app="true"
+        class="v-application v-application--is-ltr theme--light"
+        id="app"
+      >
+        <div class="v-application--wrap">
+          <main class="v-content" style="padding: 20px 0px;" data-booted="true">
+            <div class="v-content__wrap">
+              <div class="container">
+                <div class="content pt-10 pb-5">
+                  <h1 class="display-3 font-weight-thin">
+                    422 Unprocessable Entity
+                  </h1>
+                  <div class="mt-10 mb-10">
+                    <p>
+                      一時的なエラーが発生しました。
+                    </p>
+                    <p>
+                      ご不便をおかけして申し訳ございません。<br
+                        class="d-flex d-sm-none"
+                      />正常に表示されるよう、解決に取り組んでおります。
+                    </p>
+                    <p>
+                      繰り返し同様の操作をしても改善されない場合、<br
+                        class="d-flex d-sm-none"
+                      /><a
+                        class="link-text"
+                        href="https://twitter.com/Hash1og"
+                        target="_blank"
+                        >公式Twitter</a
+                      >までお問い合わせください。
+                    </p>
+                  </div>
 
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/422.html -->
-  <div class="dialog">
-    <div>
-      <h1>The change you wanted was rejected.</h1>
-      <p>Maybe you tried to change something you didn't have access to.</p>
+                  <a
+                    href="https://hashlog.work"
+                    class="v-btn--active v-btn v-btn--depressed v-btn--router theme--light v-size--default primary"
+                    ><span class="v-btn__content"
+                      ><i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--left mdi mdi-exit-run theme--light"
+                      ></i
+                      >トップページに戻る
+                    </span></a
+                  >
+                </div>
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -1,66 +1,98 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <head>
+    <title>一時的なエラーが発生しました - Hashlog</title>
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900"
+    />
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css"
+    />
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui"
+    />
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+    <style>
+      .theme--light.v-application {
+        background-color: #e9f1f6;
+      }
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+      .theme--light.v-btn:not(.v-btn--flat):not(.v-btn--text):not(.v-btn--outlined) {
+        background-color: #0079b5;
+      }
+      a.link-text {
+        color: #0079b5;
+        text-decoration: underline;
+      }
+      a.link-text:hover {
+        opacity: 0.7;
+      }
+    </style>
+  </head>
 
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+  <body>
+    <div id="app">
+      <div
+        data-app="true"
+        class="v-application v-application--is-ltr theme--light"
+        id="app"
+      >
+        <div class="v-application--wrap">
+          <main class="v-content" style="padding: 20px 0px;" data-booted="true">
+            <div class="v-content__wrap">
+              <div class="container">
+                <div class="content pt-10 pb-5">
+                  <h1 class="display-3 font-weight-thin">
+                    500 Internal Server Error
+                  </h1>
+                  <div class="mt-10 mb-10">
+                    <p>
+                      一時的なエラーが発生しました。
+                    </p>
+                    <p>
+                      ご不便をおかけして申し訳ございません。<br
+                        class="d-flex d-sm-none"
+                      />正常に表示されるよう、解決に取り組んでおります。
+                    </p>
+                    <p>
+                      しばらく待って再試行しても改善しない場合、<br
+                        class="d-flex d-sm-none"
+                      /><a
+                        class="link-text"
+                        href="https://twitter.com/Hash1og"
+                        target="_blank"
+                        >公式Twitter</a
+                      >までお問い合わせください。
+                    </p>
+                  </div>
 
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
+                  <a
+                    href="https://hashlog.work"
+                    class="v-btn--active v-btn v-btn--depressed v-btn--router theme--light v-size--default primary"
+                    ><span class="v-btn__content"
+                      ><i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--left mdi mdi-exit-run theme--light"
+                      ></i
+                      >トップページに戻る
+                    </span></a
+                  >
+                </div>
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  </body>
 </html>

--- a/spec/factories/registered_tags.rb
+++ b/spec/factories/registered_tags.rb
@@ -12,6 +12,13 @@ FactoryBot.define do
     end
   end
 
+  trait :with_3_days_tweets do
+    after(:create) do |registered_tag|
+      create_list(:tweet, 3, :tweeted_every_day, registered_tag: registered_tag)
+      registered_tag.fetch_tweets_data!
+    end
+  end
+
   # 3/7日ツイートをする
   trait :with_3_7_days_tweets do
     after(:create) do |registered_tag|

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :tag do
-    sequence(:name) { |n| "tag_#{n}" }
+    sequence(:name, 'tag_1')
   end
 
   trait :invalid do

--- a/spec/factories/tweets.rb
+++ b/spec/factories/tweets.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :tweet do
-    sequence(:oembed) { |n| "HTML #{n} <a href=\"https://twitter.com/hashtag/hast_#{n}?src=hash&amp;ref_src=twsrc%5Etfw\">#</a>" }
+    sequence(:oembed, 'HTML 1')
     tweeted_at { Time.now }
     tweet_id { rand(10 ** 19).to_s }
     registered_tag

--- a/spec/factories/tweets.rb
+++ b/spec/factories/tweets.rb
@@ -13,4 +13,8 @@ FactoryBot.define do
   trait :tweeted_7days_ago do
     tweeted_at { Time.now.ago(7.day) }
   end
+
+  trait :tweeted_every_day do
+    sequence(:tweeted_at) { |n| Time.current.ago(n.day) + 1.day }
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :user do
     twitter_id { rand(10 ** 19).to_s }
-    sequence(:name) { |n| "user_#{n}" }
-    sequence(:screen_name) { |n| "user_#{n}" }
+    sequence(:name, 'user_1')
+    sequence(:screen_name, 'user_1')
     description { '' }
     after(:build) do |user|
       create(:authentication, user: user)

--- a/spec/models/registered_tag_spec.rb
+++ b/spec/models/registered_tag_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe RegisteredTag, type: :model do
         expect(RegisteredTag.asc.last).to eq latest_tag
       end
     end
+
     describe '.desc' do
       let!(:latest_tag) { create(:registered_tag) }
       let!(:oldest_tag) { create(:registered_tag, :created_yesterday) }
@@ -60,6 +61,7 @@ RSpec.describe RegisteredTag, type: :model do
         expect(RegisteredTag.desc.last).to eq oldest_tag
       end
     end
+
     describe '.opened' do
       let(:user) { create(:user) }
       let(:published_tag) { create(:registered_tag, user: user) }
@@ -77,6 +79,17 @@ RSpec.describe RegisteredTag, type: :model do
           expect(RegisteredTag.opened).not_to include limited_tag
           expect(RegisteredTag.opened).not_to include closed_tag
         end
+      end
+    end
+
+    describe '.have_tweets' do
+      let(:registered_tag_with_tweets) { create(:registered_tag, :with_tweets) }
+      let(:registered_tag_has_no_tweets) { create(:registered_tag) }
+      it 'ツイートを持つregistered_tagを含む' do
+        expect(RegisteredTag.have_tweets).to include registered_tag_with_tweets
+      end
+      it 'ツイートを持たないregistered_tagは含まない' do
+        expect(RegisteredTag.have_tweets).not_to include registered_tag_has_no_tweets
       end
     end
   end

--- a/spec/models/registered_tag_spec.rb
+++ b/spec/models/registered_tag_spec.rb
@@ -206,6 +206,9 @@ RSpec.describe RegisteredTag, type: :model do
         it '取得したツイートを保存する' do
           expect { present_tag.create_tweets! }.to change(Tweet, :count).by(3)
         end
+        it 'fetch_tweets_data!を実行する' do
+          expect(present_tag).to receive(:fetch_tweets_data!).once
+        end
       end
       context 'ハッシュタグのツイートがTwitterに存在しないとき',
         vcr: { cassette_name: 'twitter_api/standard_search/該当のツイートがない場合' } do
@@ -214,6 +217,9 @@ RSpec.describe RegisteredTag, type: :model do
         end
         it 'ツイートを取得しないので保存しない' do
           expect { absent_tag.create_tweets! }.not_to change(Tweet, :count)
+        end
+        it 'fetch_tweets_data!を実行しない' do
+          expect(absent_tag).not_to receive(:fetch_tweets_data!)
         end
       end
     end

--- a/spec/models/registered_tag_spec.rb
+++ b/spec/models/registered_tag_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe RegisteredTag, type: :model do
         end
         it 'fetch_tweets_data!を実行する' do
           expect(present_tag).to receive(:fetch_tweets_data!).once
+          present_tag.create_tweets!
         end
       end
       context 'ハッシュタグのツイートがTwitterに存在しないとき',
@@ -220,6 +221,7 @@ RSpec.describe RegisteredTag, type: :model do
         end
         it 'fetch_tweets_data!を実行しない' do
           expect(absent_tag).not_to receive(:fetch_tweets_data!)
+          absent_tag.create_tweets!
         end
       end
     end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Tag, type: :model do
 
   describe 'scope' do
     describe '.popular' do
-      let(:popular_tag) { create(:tag, name: 'the most popular tag') }
-      let(:not_popular_tag) { create(:tag, name: 'not most popular tag') }
+      let(:popular_tag) { create(:tag, name: 'the_most_popular_tag') }
+      let(:not_popular_tag) { create(:tag, name: 'not_most_popular_tag') }
       before do
         create_list(:registered_tag, 5, tag: popular_tag)
         create_list(:registered_tag, 1, tag: not_popular_tag)
@@ -94,7 +94,7 @@ RSpec.describe Tag, type: :model do
       context 'aa#aaのように文の途中で#が入っているとき' do
         let(:tag) { build(:tag, name: 'ハッシュ##タグ') }
         it '#を消さない' do
-          tag.save!
+          tag.valid?
           expect(tag.name).to eq 'ハッシュ##タグ'
         end
       end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -16,6 +16,45 @@ RSpec.describe Tag, type: :model do
     it 'name: length <100' do
       is_expected.to validate_length_of(:name).is_at_most(100)
     end
+    describe 'name: hashtag_format' do
+      context '正常系' do
+        it 'ひらがな' do
+          is_expected.to allow_value('ひらがな', 'ぁ').for(:name)
+        end
+        it 'カタカナ' do
+          is_expected.to allow_value('カタカナ', 'ヴ').for(:name)
+        end
+        it '漢字' do
+          is_expected.to allow_value('漢字', '々').for(:name)
+        end
+        it 'Alphabet' do
+          is_expected.to allow_value('Alphabet', 'A', 'aaa').for(:name)
+        end
+        it '123半角数字と文字' do
+          is_expected.to allow_value('123半角数字と文字', '1あ2あ3').for(:name)
+        end
+        it '１２３全角数字と文字' do
+          is_expected.to allow_value('１２３全角数字と文字', '1２３あ').for(:name)
+        end
+        it '_゛゜と文字' do
+          is_expected.to allow_value('_文字_', '゛゛あ゛', '゜゜あ゜').for(:name)
+        end
+      end
+      context '異常系' do
+        it '記号混じり' do
+          is_expected.not_to allow_value('あ#あ', 'あ@あ', 'あ-あ', 'あ。あ', 'あ、あ', 'あ,あ', 'あ.あ').for(:name)
+        end
+        it '数字のみ' do
+          is_expected.not_to allow_value('111', '１１１').for(:name)
+        end
+        it '_゛゜のみ' do
+          is_expected.not_to allow_value('_', '___', '゛', '゜').for(:name)
+        end
+        it 'ああ あ（スペース混じり）' do
+          is_expected.not_to allow_value('あ　あ', 'あ あ', ' あ', '　あ').for(:name)
+        end
+      end
+    end
   end
 
   describe 'scope' do
@@ -37,6 +76,7 @@ RSpec.describe Tag, type: :model do
 
   describe 'methods' do
     describe '#remove_first_hashtag_mark' do
+      # tagのバリデーションのための部分は上の'name: hashtag_format'の項目でテストする
       context '先頭に#が入っているとき' do
         let(:tag) { build(:tag, name: '#ハッシュタグ') }
         it '#を消した文字列になる' do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -34,4 +34,30 @@ RSpec.describe Tag, type: :model do
       end
     end
   end
+
+  describe 'methods' do
+    describe '#remove_first_hashtag_mark' do
+      context '先頭に#が入っているとき' do
+        let(:tag) { build(:tag, name: '#ハッシュタグ') }
+        it '#を消した文字列になる' do
+          tag.save!
+          expect(tag.name).to eq 'ハッシュタグ'
+        end
+      end
+      context '先頭に###が入っているとき' do
+        let(:tag) { build(:tag, name: '###ハッシュタグ') }
+        it '###を消した文字列になる' do
+          tag.save!
+          expect(tag.name).to eq 'ハッシュタグ'
+        end
+      end
+      context 'aa#aaのように文の途中で#が入っているとき' do
+        let(:tag) { build(:tag, name: 'ハッシュ##タグ') }
+        it '#を消さない' do
+          tag.save!
+          expect(tag.name).to eq 'ハッシュ##タグ'
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/registered_tags/persistences_spec.rb
+++ b/spec/requests/api/v1/registered_tags/persistences_spec.rb
@@ -1,25 +1,25 @@
 RSpec.describe 'RegisteredTags', type: :request do
-  fdescribe 'GET /api/v1/registered_tags/persistences' do
-    let(:registered_tags) { RegisteredTag.opened.includes(:user, :tag).have_tweets.persistence_sort }
+  describe 'GET /api/v1/registered_tags/persistences' do
+    let(:registered_tags) { RegisteredTag.includes(:user, :tag).opened.have_tweets.persistence_sort }
     let(:tags_json) { json['registeredTags'] }
     before do
-      create_list(:registered_tag, 50)
+      create_list(:registered_tag, 3, :with_3_7_days_tweets)
       get '/api/v1/registered_tags/persistences'
     end
     describe '全般的なこと' do
       it '200 OKを返す' do
         expect(response.status).to eq 200
       end
-      it 'RegisteredTag.ascのJSONを返す' do
+      it 'RegisteredTag.opened.have_tweets.persistence_sortのJSONを返す' do
         tags_json.zip(registered_tags).each do |tag_json, registered_tag|
           expect(tag_json).to eq({
             'id' => registered_tag.id,
             'tweetedDayCount' => registered_tag.tweeted_day_count,
             'privacy' => registered_tag.privacy_i18n,
             'remindDay' => nil,
-            'tweetRate' => 0,
-            'firstTweetedAt' => registered_tag.first_tweeted_at,
-            'lastTweetedAt' => registered_tag.last_tweeted_at,
+            'tweetRate' => registered_tag.tweet_rate,
+            'firstTweetedAt' => registered_tag.first_tweeted_at.strftime('%FT%T.%L%:z'),
+            'lastTweetedAt' => registered_tag.last_tweeted_at.strftime('%FT%T.%L%:z'),
             'tag' => {
               'id' => registered_tag.tag.id,
               'name' => registered_tag.tag.name,
@@ -35,19 +35,15 @@ RSpec.describe 'RegisteredTags', type: :request do
     end
     describe 'ソート' do
       let!(:registered_tag_with_no_tweets) { create(:registered_tag) }
-      let!(:tag_with_42_per) { create(:registered_tag, :with_3_7_days_tweets) }
-      let(:today_tweet) { create(:tweet) }
-      let!(:tag_with_100_per) { today_tweet.registered_tag }
-      before do
-        tag_with_100_per.fetch_tweets_data!
-        get '/api/v1/registered_tags/persistences'
-      end
-      it 'ツイートの割合が多い順に並ぶ' do
-        expect(tags_json.first['id']).to eq tag_with_100_per.id
-        expect(tags_json.second['id']).to eq tag_with_42_per.id
+      let!(:tag_100_per_3_days) { create(:registered_tag, :with_3_days_tweets) }
+      let!(:tag_100_per_1_day) { create(:registered_tag, :with_tweets) }
+      before { get '/api/v1/registered_tags/persistences' }
+      it 'ツイートの割合が多くかつツイート日数が多いものが一番になる' do
+        expect(tags_json.first['id']).to eq tag_100_per_3_days.id
+        expect(tags_json.second['id']).to eq tag_100_per_1_day.id
       end
       it 'ツイートがないregistered_tagを含めない' do
-        expect(tags_json).to include({
+        expect(tags_json).not_to include({
           'id' => registered_tag_with_no_tweets.id,
           'tweetedDayCount' => registered_tag_with_no_tweets.tweeted_day_count,
           'privacy' => registered_tag_with_no_tweets.privacy_i18n,
@@ -72,21 +68,15 @@ RSpec.describe 'RegisteredTags', type: :request do
       let!(:closed_registered_tag) { create(:registered_tag, :closed) }
       it '限定公開のタグを返さない' do
         expect(tags_json).not_to include 'id' => limited_registered_tag.id
-        get '/api/v1/registered_tags/persistences?page=2'
-        expect(tags_json).not_to include 'id' => limited_registered_tag.id
-        get '/api/v1/registered_tags/persistences?page=3'
-        expect(tags_json).not_to include 'id' => limited_registered_tag.id
       end
       it '非公開のタグを返さない' do
-        expect(tags_json).not_to include 'id' => closed_registered_tag.id
-        get '/api/v1/registered_tags/persistences?page=2'
-        expect(tags_json).not_to include 'id' => closed_registered_tag.id
-        get '/api/v1/registered_tags/persistences?page=3'
         expect(tags_json).not_to include 'id' => closed_registered_tag.id
       end
     end
     describe 'pagy' do
+      before { create_list(:registered_tag, 50, :with_3_7_days_tweets) }
       it 'pageクエリがないとき 20件返す' do
+        get '/api/v1/registered_tags/persistences'
         expect(tags_json.length).to eq 20
       end
       it 'page=2のとき 10件返す' do

--- a/spec/requests/api/v1/registered_tags_spec.rb
+++ b/spec/requests/api/v1/registered_tags_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'RegisteredTags', type: :request do
             'code' => '422',
             'title' => '登録内容が適切ではありません',
             'detail' => '登録内容を確認してください',
-            'messages' => %w[名前が不適な形式です 名前を入力してください]
+            'messages' => %w[名前の入力形式が不適です 名前を入力してください]
           })
         end
         it 'current_user.registered_tagsを作成しない' do

--- a/spec/requests/api/v1/registered_tags_spec.rb
+++ b/spec/requests/api/v1/registered_tags_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'RegisteredTags', type: :request do
             'code' => '422',
             'title' => '登録内容が適切ではありません',
             'detail' => '登録内容を確認してください',
-            'messages' => ['名前を入力してください']
+            'messages' => %w[名前が不適な形式です 名前を入力してください]
           })
         end
         it 'current_user.registered_tagsを作成しない' do


### PR DESCRIPTION
## 概要
fix #125
fix #44
close #24

- 毎日ツイート取得時に新規でツイートを取得した際、初めてのツイート日が登録されていなかったのを修正
- ランキングのロジックを変更
  - 継続率の高い順かつ日数が多い順
  - 0日の場合は表示しない
- 説明文を追加
  - ハッシュタグ登録画面
  - ユーザー情報編集画面
- 長いユーザーネームの場合、プロフィールでTwitterアイコンが見えなくなるのを修正
- Routing Errorのときに返すテンプレートのフォーマットをHTMLに指定
- サーバー側のエラーページを作成
- ハッシュタグのバリデーションを追加  
先頭に#がある場合のみこちら側で取り除く