### PR TITLE
カレンダー用のエンドポイントを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/aiandrox/hashlog/badge.svg?branch=develop)](https://coveralls.io/github/aiandrox/hashlog?branch=develop)
 [![Maintainability](https://api.codeclimate.com/v1/badges/d31e5fff03ec3ea494fa/maintainability)](https://codeclimate.com/github/aiandrox/hashlog/maintainability)
 
-https://hashlog.work
+### **https://hashlog.work**
 
 ## サービス概要
 
@@ -97,6 +97,7 @@ https://drive.google.com/file/d/1xGTZvsnf1Tqezl44daZW8v8j_zwY8kEK/view?usp=shari
 
 ### インフラストラクチャー
 
+- ~~Docker~~
 - Sider
 - CircleCI
 - Nginx 1.12.2

--- a/app/controllers/api/v1/tweeted_ats_controller.rb
+++ b/app/controllers/api/v1/tweeted_ats_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::TweetedAtsController < Api::V1::BaseController
+  def index
+    registered_tag = RegisteredTag.find(params[:registered_tag_id])
+    authorize!(registered_tag)
+    tweeted_ats = registered_tag.tweets.tweeted_ats.map(&:tweeted_at).map(&:to_s)
+    render json: { tweetedAts: tweeted_ats }
+  end
+end

--- a/app/javascript/components/TheTagWrapper.vue
+++ b/app/javascript/components/TheTagWrapper.vue
@@ -118,9 +118,9 @@ export default {
     async fetchTweetDates() {
       this.tweetDates = []
       const { tagId } = this.$route.params
-      const tweetsRes = await this.$axios.get(`${this.registeredTagUrl}/tweets`)
-      const { tweets } = tweetsRes.data
-      tweets.forEach(t => this.tweetDates.push(t.tweetedAt.substr(0, 10)))
+      const tweetsRes = await this.$axios.get(`${this.registeredTagUrl}/tweeted_ats`)
+      const { tweetedAts } = tweetsRes.data
+      tweetedAts.forEach(t => this.tweetDates.push(t.substr(0, 10)))
       this.date = ""
     },
     // カレンダーの日付の変更

--- a/app/loyalties/api/v1/tweeted_ats_loyalty.rb
+++ b/app/loyalties/api/v1/tweeted_ats_loyalty.rb
@@ -5,8 +5,7 @@ class Api::V1::TweetedAtsLoyalty < ApplicationLoyalty
   end
 
   def index?
-    registered_tag.user == current_user ||
-      (registered_tag.user.published? && !registered_tag.closed?)
+    Api::V1::RegisteredTagsLoyalty.new(current_user, registered_tag).show?
   end
 
   private

--- a/app/loyalties/api/v1/tweeted_ats_loyalty.rb
+++ b/app/loyalties/api/v1/tweeted_ats_loyalty.rb
@@ -1,0 +1,15 @@
+class Api::V1::TweetedAtsLoyalty < ApplicationLoyalty
+  def initialize(current_user, registered_tag)
+    @current_user = current_user
+    @registered_tag = registered_tag
+  end
+
+  def index?
+    registered_tag.user == current_user ||
+      (registered_tag.user.published? && !registered_tag.closed?)
+  end
+
+  private
+
+  attr_reader :current_user, :registered_tag
+end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -11,6 +11,7 @@ class Tweet < ApplicationRecord
     formated_date = "date_format(tweeted_at, '%Y%m%d')"
     select(formated_date).group(formated_date).length
   }
+  scope :tweeted_ats, -> { select(:tweeted_at) }
   scope :tweeted_at_date, ->(date) { where(tweeted_at: date.beginning_of_day..date.end_of_day) }
 
   def self.latest

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
         resources :persistences, only: %i[index]
       end
       resources :registered_tags, only: %i[index show create update destroy] do
+        resources :tweeted_ats, only: %i[index]
         resources :tweets, only: %i[index]
       end
       resources :tags, only: %i[index]

--- a/spec/loyalties/tweeted_ats_loyalty_spec.rb
+++ b/spec/loyalties/tweeted_ats_loyalty_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe 'TweetedAtsLoyalty', type: :request do
+  describe 'GET /api/v1/registered_tags/:id/tweeted_ats' do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:my_registered_tag) { create(:registered_tag, user: user) }
+    let(:other_registered_tag) { create(:registered_tag, user: other_user) }
+    before { login_as(user) }
+    context '自分のタグのとき' do
+      subject { get "/api/v1/registered_tags/#{my_registered_tag.id}/tweeted_ats" }
+      it 'ユーザーの公開設定にかかわらず取得できる' do
+        user.published!
+        subject
+        expect(response.status).to eq 200
+
+        user.closed!
+        subject
+        expect(response.status).to eq 200
+      end
+      it 'タグの公開設定にかかわらず取得できる' do
+        my_registered_tag.published!
+        subject
+        expect(response.status).to eq 200
+
+        my_registered_tag.limited!
+        subject
+        expect(response.status).to eq 200
+
+        my_registered_tag.closed!
+        subject
+        expect(response.status).to eq 200
+      end
+    end
+    context '他人のタグのとき' do
+      context '作成ユーザーが公開のとき' do
+        subject { get "/api/v1/registered_tags/#{other_registered_tag.id}/tweeted_ats" }
+        it '公開/限定公開のタグを取得できる' do
+          other_registered_tag.published!
+          subject
+          expect(response.status).to eq 200
+
+          other_registered_tag.limited!
+          subject
+          expect(response.status).to eq 200
+        end
+        it '非公開のタグを取得できない' do
+          other_registered_tag.closed!
+          subject
+          expect(response.status).to eq 403
+        end
+      end
+      context '作成ユーザーが非公開のとき' do
+        before { other_user.closed! }
+        it 'タグの公開設定にかかわらずタグを取得できない' do
+          other_registered_tag.published!
+          subject
+          expect(response.status).to eq 403
+
+          other_registered_tag.limited!
+          subject
+          expect(response.status).to eq 403
+
+          other_registered_tag.published!
+          subject
+          expect(response.status).to eq 403
+        end
+      end
+    end
+  end
+end

--- a/spec/loyalties/tweeted_ats_loyalty_spec.rb
+++ b/spec/loyalties/tweeted_ats_loyalty_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe 'TweetedAtsLoyalty', type: :request do
       end
     end
     context '他人のタグのとき' do
+      subject { get "/api/v1/registered_tags/#{other_registered_tag.id}/tweeted_ats" }
       context '作成ユーザーが公開のとき' do
-        subject { get "/api/v1/registered_tags/#{other_registered_tag.id}/tweeted_ats" }
         it '公開/限定公開のタグを取得できる' do
           other_registered_tag.published!
           subject

--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Tweet, type: :model do
         expect(Tweet.desc.last).to eq oldest_tweet
       end
     end
+
     describe '.tweeted_day_count' do
       it 'tweetが存在する日数を返す' do
         create_list(:tweet, 3, tweeted_at: Time.now)
@@ -40,6 +41,15 @@ RSpec.describe Tweet, type: :model do
         expect(Tweet.tweeted_day_count).to eq 3
       end
     end
+
+    describe '.tweeted_ats' do
+      xit 'tweeted_atのみを返す' do
+        create_list(:tweet, 3)
+        # keyを確認したい
+        expect(Tweet.tweeted_ats).not_to include 'aaa'
+      end
+    end
+
     describe '.tweeted_at_date(date)' do
       let(:the_day) { Time.parse('2020-06-01') }
       let!(:prev_day_tweet) { create(:tweet, tweeted_at: the_day.prev_day.end_of_day) }

--- a/spec/requests/api/v1/tweeted_ats_spec.rb
+++ b/spec/requests/api/v1/tweeted_ats_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe 'TweetedAts', type: :request do
+  describe 'GET /api/v1/registered_tags/:regsitered_tag_id/tweeted_ats' do
+    let(:registered_tag) { create(:registered_tag) }
+    let(:tweeted_ats_json) { json['tweetedAts'] }
+    let(:tweets) { registered_tag.tweets }
+    describe '全般的なこと' do
+      before do
+        create_list(:tweet, 10, registered_tag: registered_tag)
+        get "/api/v1/registered_tags/#{registered_tag.id}/tweeted_ats"
+      end
+      it '200 OKを返す' do
+        expect(response.status).to eq 200
+      end
+      it 'tweeted_atのJSONを返す' do
+        tweeted_ats_json.zip(tweets).each do |tweet_json, tweet|
+          expect(tweet_json).to include tweet.tweeted_at.to_s[0..9]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

以前はカレンダー表示のためにすべてのツイートデータを取得していたので、tweeted_atのみを返すエンドポイントを追加した。

## 使用gemや外部ツール


## 確認手順

1. Gem を追加したので `bundle install` を実行してください
2. カラムを追加したので `bundle exec rails db:migrate` を実行してください

## 想定される影響範囲

- データベース
- gem

## コメント

- レビュワーに見てほしい点
- 気づき

## 参考資料

公式リファレンスや参考記事へのリンク