### PR TITLE
exception_notificationでcurrent_userを送信する

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -4,6 +4,8 @@ class Api::V1::BaseController < ApplicationController
   include Banken
   include ErrorsHandler
   include Pagy::Backend
+
+  before_action :prepare_exception_notifier
   after_action :set_pagy_header, if: -> { @pagy }
 
   rescue_from Exception, with: :notify_500
@@ -17,5 +19,15 @@ class Api::V1::BaseController < ApplicationController
   def set_pagy_header
     pagy_headers_merge(@pagy)
     response.headers.merge!({ 'Request-Url' => request.path_info })
+  end
+
+  private
+
+  def prepare_exception_notifier
+    return unless current_user
+
+    request.env['exception_notifier.exception_data'] = {
+      current_user: current_user.to_json
+    }
   end
 end

--- a/app/controllers/concerns/errors_handler.rb
+++ b/app/controllers/concerns/errors_handler.rb
@@ -4,10 +4,7 @@ module ErrorsHandler
   protected
 
   def notify_500(exception)
-    if Rails.env.production?
-      logger.error "500 error: #{exception.message}\n#{exception.backtrace}"
-      ExceptionNotifier.notify_exception(exception, env: request.env)
-    end
+    logger.error "500 error: #{exception.message}\n#{exception.backtrace}" if Rails.env.production?
     raise exception
   end
 


### PR DESCRIPTION
## 概要
close #185

![image](https://user-images.githubusercontent.com/44717752/100493747-721b5900-317d-11eb-9638-1543141455a7.png)


`ExceptionNotifier.notify_exception(exception, env: request.env)`が動いていないので削除
本当はparamsも通知したい