### PR TITLE
[Rename] TwitterAPIClient → TwitterApiClient

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::BaseController < ApplicationController
   rescue_from Banken::NotAuthorizedError, with: :not_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :rescue_not_found
   rescue_from Twitter::Error::TooManyRequests, with: :rescue_limited_twitter_requests
-  rescue_from TwitterAPIClient::NotFoundAuthenticationError, with: :rescue_not_found_authentication
+  rescue_from TwitterApiClient::NotFoundAuthenticationError, with: :rescue_not_found_authentication
 
   protected
 

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::TweetsController < Api::V1::BaseController
 
   def create
     registered_tag = current_user.registered_tags.find(params[:registered_tag_id])
-    update_client = TwitterAPI::Update.new(
+    update_client = TwitterApi::Update.new(
       user: current_user,
       tag: registered_tag.tag,
       body: tweet_params[:body]

--- a/app/controllers/api/v1/users/current/twitter_data_controller.rb
+++ b/app/controllers/api/v1/users/current/twitter_data_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::Users::Current::TwitterDataController < Api::V1::BaseController
 
   def update
     authorize!
-    TwitterAPI::User.new(current_user).call
+    TwitterApi::User.new(current_user).call
     render json: current_user, status: :ok
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
       tag.save!
       registered_tag = registered_tags.build(tag_id: tag.id)
       registered_tag.save!
-      tweets_data = TwitterAPI::UserTweets.new(self, registered_tag.tag.name).call # ('premium')
+      tweets_data = TwitterApi::UserTweets.new(self, registered_tag.tag.name).call # ('premium')
       registered_tag.create_tweets(tweets_data)
       true
     rescue ActiveRecord::RecordInvalid

--- a/app/services/job/add_tweets.rb
+++ b/app/services/job/add_tweets.rb
@@ -1,6 +1,6 @@
 module Job
   class AddTweets
-    include TwitterAPIClient
+    include TwitterApiClient
     attr_reader :notify_logs
 
     def initialize(registered_tags = RegisteredTag.all.includes(:user, :tag))
@@ -20,7 +20,7 @@ module Job
 
     def collect_tweets(registered_tag)
       collect(registered_tag, registered_tag.user)
-    rescue TwitterAPIClient::NotFoundAuthenticationError
+    rescue TwitterApiClient::NotFoundAuthenticationError
       user = User.admin.first
       collect(registered_tag, user)
     rescue StandardError => e

--- a/app/services/job/add_tweets.rb
+++ b/app/services/job/add_tweets.rb
@@ -31,7 +31,7 @@ module Job
     def collect(registered_tag, user)
       last_tweet = registered_tag.tweets.latest
       unless last_tweet
-        tweets_data = TwitterAPI::UserTweets.new(user, registered_tag.tag.name).call
+        tweets_data = TwitterApi::UserTweets.new(user, registered_tag.tag.name).call
         registered_tag.create_tweets(tweets_data)
         return
       end
@@ -39,7 +39,7 @@ module Job
       return if last_tweet.tweeted_at > Time.current.prev_day.beginning_of_day
 
       since_id = last_tweet.tweet_id.to_i
-      tweet_data = TwitterAPI::UserTweets.new(user, registered_tag.tag.name, since_id)
+      tweet_data = TwitterApi::UserTweets.new(user, registered_tag.tag.name, since_id)
                                          .call('everyday')
       message = "@#{registered_tag.user.screen_name} の ##{registered_tag.tag.name} にツイートを追加"
       registered_tag.add_tweets(tweet_data).any? && notify_logs << message && Rails.logger.info(message)

--- a/app/services/job/remind_reply.rb
+++ b/app/services/job/remind_reply.rb
@@ -1,6 +1,6 @@
 module Job
   class RemindReply
-    include TwitterAPIClient
+    include TwitterApiClient
     attr_reader :notify_logs
 
     def initialize(registered_tags = RegisteredTag.all.includes(:user, :tag))

--- a/app/services/job/update_user_twitter_data.rb
+++ b/app/services/job/update_user_twitter_data.rb
@@ -17,7 +17,7 @@ module Job
     private
 
     def fetch(user)
-      TwitterAPI::User.new(user).call
+      TwitterApi::User.new(user).call
     rescue StandardError => e
       message = "@#{user.screen_name}: #{e}"
       notify_logs << message && Rails.logger.error(message)

--- a/app/services/job/update_user_twitter_data.rb
+++ b/app/services/job/update_user_twitter_data.rb
@@ -1,6 +1,6 @@
 module Job
   class UpdateUserTwitterData
-    include TwitterAPIClient
+    include TwitterApiClient
     attr_reader :notify_logs
 
     def initialize(users = User.not_deleted)

--- a/app/services/twitter_api/add_images.rb
+++ b/app/services/twitter_api/add_images.rb
@@ -1,4 +1,4 @@
-module TwitterAPI
+module TwitterApi
   class AddImages
     include TwitterApiClient
 

--- a/app/services/twitter_api/add_images.rb
+++ b/app/services/twitter_api/add_images.rb
@@ -1,6 +1,6 @@
 module TwitterAPI
   class AddImages
-    include TwitterAPIClient
+    include TwitterApiClient
 
     def self.call(tweet)
       new.call(tweet)

--- a/app/services/twitter_api/update.rb
+++ b/app/services/twitter_api/update.rb
@@ -1,6 +1,6 @@
 module TwitterAPI
   class Update
-    include TwitterAPIClient
+    include TwitterApiClient
     include ActiveModel::Validations
 
     attr_reader :user, :tag, :body

--- a/app/services/twitter_api/update.rb
+++ b/app/services/twitter_api/update.rb
@@ -1,4 +1,4 @@
-module TwitterAPI
+module TwitterApi
   class Update
     include TwitterApiClient
     include ActiveModel::Validations

--- a/app/services/twitter_api/user.rb
+++ b/app/services/twitter_api/user.rb
@@ -1,6 +1,6 @@
 module TwitterAPI
   class User
-    include TwitterAPIClient
+    include TwitterApiClient
 
     def initialize(user)
       @user = user

--- a/app/services/twitter_api/user.rb
+++ b/app/services/twitter_api/user.rb
@@ -1,4 +1,4 @@
-module TwitterAPI
+module TwitterApi
   class User
     include TwitterApiClient
 

--- a/app/services/twitter_api/user_tweets.rb
+++ b/app/services/twitter_api/user_tweets.rb
@@ -1,4 +1,4 @@
-module TwitterAPI
+module TwitterApi
   class UserTweets
     include TwitterApiClient
 

--- a/app/services/twitter_api/user_tweets.rb
+++ b/app/services/twitter_api/user_tweets.rb
@@ -1,6 +1,6 @@
 module TwitterAPI
   class UserTweets
-    include TwitterAPIClient
+    include TwitterApiClient
 
     def initialize(user, tag_name, since_id = nil)
       @tweet_ids = []

--- a/app/services/twitter_api_client.rb
+++ b/app/services/twitter_api_client.rb
@@ -1,6 +1,6 @@
 require 'twitter'
 
-module TwitterAPIClient
+module TwitterApiClient
   class NotFoundAuthenticationError < StandardError
   end
 

--- a/spec/requests/api/v1/base_spec.rb
+++ b/spec/requests/api/v1/base_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Base', type: :request do
   let(:user) { create(:user, screen_name: 'user') }
   describe '#rescue_limited_twitter_requests' do
-    context 'TwitterAPIのリクエストが上限に達した場合',
+    context 'TwitterApiのリクエストが上限に達した場合',
       vcr: { cassette_name: 'twitter_api/standard_search/Twitter::Error::TooManyRequests' } do
       before do
         login_as(user)

--- a/spec/services/cron_twitter.rb
+++ b/spec/services/cron_twitter.rb
@@ -3,7 +3,7 @@ RSpec.describe CronTwitter do
 
   describe 'CronTwitter#call' do
     context '引数に Job::AddTweets.new を渡すとき',
-      vcr: { cassette_name: 'add_tweets_job TwitterAPIとWebhooks' } do
+      vcr: { cassette_name: 'add_tweets_job TwitterApiとWebhooks' } do
       let(:add_tweets) { Job::AddTweets.new }
       xit 'ログを出力する' do
         expect(Rails.logger).to receive(:info)

--- a/spec/services/twitter_api/user_spec.rb
+++ b/spec/services/twitter_api/user_spec.rb
@@ -1,4 +1,4 @@
-describe TwitterAPI::User do
+describe TwitterApi::User do
   let(:user) do
     create(
       :user,
@@ -10,7 +10,7 @@ describe TwitterAPI::User do
     )
   end
   describe '#call', vcr: { cassette_name: 'twitter_api/user_show/hashlog' } do
-    let(:user_data) { TwitterAPI::User.new(user) }
+    let(:user_data) { TwitterApi::User.new(user) }
     subject { user_data.call }
     it 'Twitterのアカウントから取得したユーザーのデータを更新する' do
       expect { subject }.to change { user.reload.name }.to('Hashlog').from('古い名前')

--- a/spec/services/twitter_api/user_tweets_spec.rb
+++ b/spec/services/twitter_api/user_tweets_spec.rb
@@ -1,10 +1,10 @@
-describe TwitterAPI::UserTweets do
+describe TwitterApi::UserTweets do
   let(:user) { create(:user, :real_value) }
   describe '#call' do
     context '該当のツイートがない場合',
       vcr: { cassette_name: 'twitter_api/standard_search/該当のツイートがない場合' } do
       let(:tag) { create(:tag, name: 'absent_tag') }
-      let(:tweets_data) { TwitterAPI::UserTweets.new(user, tag.name) }
+      let(:tweets_data) { TwitterApi::UserTweets.new(user, tag.name) }
       it '空の配列を返す' do
         expect(tweets_data.call).to eq([])
       end
@@ -32,7 +32,7 @@ describe TwitterAPI::UserTweets do
       end
       context '"standard"を引数に渡すとき' do
         let(:type) { 'standard' }
-        let(:tweets_data) { TwitterAPI::UserTweets.new(user, tag.name) }
+        let(:tweets_data) { TwitterApi::UserTweets.new(user, tag.name) }
         it '#standard_searchを実行する' do
           expect(tweets_data).to receive(:standard_search).once
           tweets_data.call(type)
@@ -41,7 +41,7 @@ describe TwitterAPI::UserTweets do
       end
       context '"premium"を引数に渡すとき' do
         let(:type) { 'premium' }
-        let(:tweets_data) { TwitterAPI::UserTweets.new(user, tag.name) }
+        let(:tweets_data) { TwitterApi::UserTweets.new(user, tag.name) }
         it '#premiun_searchを実行する' do
           expect(tweets_data).to receive(:premium_search).once
           tweets_data.call(type)
@@ -51,7 +51,7 @@ describe TwitterAPI::UserTweets do
       context '"everyday"を引数に渡すとき' do
         let(:type) { 'everyday' }
         let(:since_id) { '1255854602626330624' }
-        let(:tweets_data) { TwitterAPI::UserTweets.new(user, tag.name, since_id) }
+        let(:tweets_data) { TwitterApi::UserTweets.new(user, tag.name, since_id) }
         it '#everyday_searchを実行する' do
           expect(tweets_data).to receive(:everyday_search).once
           tweets_data.call(type)


### PR DESCRIPTION
```
 /app/vendor/bundle/ruby/2.7.0/gems/zeitwerk-2.5.4/lib/zeitwerk/loader/callbacks.rb:25:in `on_file_autoloaded': expected file /app/app/services/twitter_api_client.rb to define constant TwitterApiClient, but didn't (Zeitwerk::NameError)
```
