### PR TITLE
ハッシュタグを登録→ツイートのときに「はじめてのツイート」がセットされない を解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'annotate'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
       momentjs-rails (~> 2.8)
       sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     banken (1.0.3)
       activesupport (>= 3.0.0)
@@ -448,6 +451,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   administrate
+  annotate
   banken
   bootsnap
   bullet

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::TweetsController < Api::V1::BaseController
       body: tweet_params[:body]
     )
     if (tweet_data = update_client.call)
-      registered_tag.add_tweets([tweet_data])
+      registered_tag.create_tweets([tweet_data])
       tweet = registered_tag.tweets.desc.first
       render json: tweet, status: :created
     else

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: authentications
+#
+#  id                  :bigint           not null, primary key
+#  user_id             :integer          not null
+#  provider            :string(255)      not null
+#  uid                 :string(255)      not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  access_token        :string(255)      default(""), not null
+#  access_token_secret :string(255)      default(""), not null
+#
 class Authentication < ApplicationRecord
   before_save :encrypt_access_token
   belongs_to :user

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: images
+#
+#  id       :bigint           not null, primary key
+#  alt      :string(255)      not null
+#  src      :string(255)      not null
+#  tweet_id :bigint           not null
+#
 class Image < ApplicationRecord
   belongs_to :tweet
 end

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: registered_tags
+#
+#  id               :bigint           not null, primary key
+#  user_id          :bigint
+#  tag_id           :bigint
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  privacy          :integer          default("published"), not null
+#  remind_day       :integer          default(0), not null
+#  first_tweeted_at :datetime
+#
 class RegisteredTag < ApplicationRecord
   DAY_COUNT_MONTH = 30
   NONE = 0

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -79,6 +79,12 @@ class RegisteredTag < ApplicationRecord
     add_tweets(tweets_data_array).any? && fetch_tweets_data!
   end
 
+  private
+
+  def fetch_tweets_data!
+    update!(first_tweeted_at: tweets.oldest.tweeted_at) if tweets.any?
+  end
+
   def add_tweets(tweets_data_array)
     tweets_data_array.each do |oembed, tweeted_at, tweet_id, medias|
       tweets.create_with_images!(
@@ -89,12 +95,6 @@ class RegisteredTag < ApplicationRecord
       )
     end
   end
-
-  def fetch_tweets_data!
-    update!(first_tweeted_at: tweets.oldest.tweeted_at) if tweets.any?
-  end
-
-  private
 
   def filter_remind_day
     self.remind_day = NONE if remind_day.nil?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Tag < ApplicationRecord
   before_validation :remove_first_hashtag_mark
 

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -38,9 +38,8 @@ class Tweet < ApplicationRecord
   def self.create_with_images!(oembed:, tweeted_at:, tweet_id:, medias:)
     ActiveRecord::Base.transaction do
       tweet = create!(oembed: oembed, tweeted_at: tweeted_at, tweet_id: tweet_id)
-      return unless medias # ツイート取得時は画像はないのでreturn
 
-      medias.each do |media|
+      medias&.each do |media|
         tweet.images.find_or_create_by!(
           alt: tweet.registered_tag.tag.name,
           src: media.media_url.to_s

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: tweets
+#
+#  id                :bigint           not null, primary key
+#  registered_tag_id :bigint
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  oembed            :text(65535)      not null
+#  tweeted_at        :datetime         not null
+#  tweet_id          :string(255)      not null
+#
 class Tweet < ApplicationRecord
   belongs_to :registered_tag
   has_many :images, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id          :bigint           not null, primary key
+#  twitter_id  :string(255)      not null
+#  uuid        :string(255)      not null
+#  name        :string(255)      not null
+#  description :text(65535)
+#  privacy     :integer          default("published"), not null
+#  role        :integer          default("general"), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  screen_name :string(255)      not null
+#  avatar_url  :string(255)      default("https://abs.twimg.com/sticky/default_profile_images/default_profile.png"), not null
+#
 class User < ApplicationRecord
   before_create :set_uuid
   before_save :replace_user_data

--- a/app/serializers/registered_tag_serializer.rb
+++ b/app/serializers/registered_tag_serializer.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: registered_tags
+#
+#  id               :bigint           not null, primary key
+#  user_id          :bigint
+#  tag_id           :bigint
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  privacy          :integer          default("published"), not null
+#  remind_day       :integer          default(0), not null
+#  first_tweeted_at :datetime
+#
 class RegisteredTagSerializer < ActiveModel::Serializer
   attributes :id, :tweeted_day_count, :privacy, :remind_day,
              :first_tweeted_at, :last_tweeted_at, :tweet_rate

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class TagSerializer < ActiveModel::Serializer
   attributes :id, :name
 end

--- a/app/serializers/tweet_serializer.rb
+++ b/app/serializers/tweet_serializer.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: tweets
+#
+#  id                :bigint           not null, primary key
+#  registered_tag_id :bigint
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  oembed            :text(65535)      not null
+#  tweeted_at        :datetime         not null
+#  tweet_id          :string(255)      not null
+#
 class TweetSerializer < ActiveModel::Serializer
   attributes :id, :tweet_id, :oembed, :tweeted_at
   has_many :images

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id          :bigint           not null, primary key
+#  twitter_id  :string(255)      not null
+#  uuid        :string(255)      not null
+#  name        :string(255)      not null
+#  description :text(65535)
+#  privacy     :integer          default("published"), not null
+#  role        :integer          default("general"), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  screen_name :string(255)      not null
+#  avatar_url  :string(255)      default("https://abs.twimg.com/sticky/default_profile_images/default_profile.png"), not null
+#
 class UserSerializer < ActiveModel::Serializer
   attributes :uuid, :twitter_id, :name, :screen_name, :description, :privacy, :role, :avatar_url
 

--- a/spec/factories/authentications.rb
+++ b/spec/factories/authentications.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: authentications
+#
+#  id                  :bigint           not null, primary key
+#  user_id             :integer          not null
+#  provider            :string(255)      not null
+#  uid                 :string(255)      not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  access_token        :string(255)      default(""), not null
+#  access_token_secret :string(255)      default(""), not null
+#
 FactoryBot.define do
   factory :authentication do
     uid { rand(10 ** 19).to_s }

--- a/spec/factories/registered_tags.rb
+++ b/spec/factories/registered_tags.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: registered_tags
+#
+#  id               :bigint           not null, primary key
+#  user_id          :bigint
+#  tag_id           :bigint
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  privacy          :integer          default("published"), not null
+#  remind_day       :integer          default(0), not null
+#  first_tweeted_at :datetime
+#
 FactoryBot.define do
   factory :registered_tag do
     user

--- a/spec/factories/registered_tags.rb
+++ b/spec/factories/registered_tags.rb
@@ -31,14 +31,14 @@ FactoryBot.define do
 
       after(:create) do |registered_tag, evaluator|
         create_list(:tweet, evaluator.count, registered_tag: registered_tag)
-        registered_tag.fetch_tweets_data!
+        registered_tag.update!(first_tweeted_at: registered_tag.tweets.oldest.tweeted_at)
       end
     end
 
     trait :with_3_days_tweets do
       after(:create) do |registered_tag|
-        create_list(:tweet, 3, :tweeted_every_day, registered_tag: registered_tag)
-        registered_tag.fetch_tweets_data!
+        tweets = create_list(:tweet, 3, :tweeted_every_day, registered_tag: registered_tag)
+        registered_tag.update!(first_tweeted_at: registered_tag.tweets.oldest.tweeted_at)
       end
     end
 
@@ -48,7 +48,8 @@ FactoryBot.define do
         create(:tweet, :tweeted_yesterday, registered_tag: registered_tag)
         create(:tweet, tweeted_at: Time.now.ago(3.day), registered_tag: registered_tag)
         create(:tweet, :tweeted_7days_ago, registered_tag: registered_tag)
-        registered_tag.fetch_tweets_data!
+
+        registered_tag.update!(first_tweeted_at: registered_tag.tweets.oldest.tweeted_at)
       end
     end
 

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :tag do
     sequence(:name, 'tag_1')

--- a/spec/factories/tweets.rb
+++ b/spec/factories/tweets.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: tweets
+#
+#  id                :bigint           not null, primary key
+#  registered_tag_id :bigint
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  oembed            :text(65535)      not null
+#  tweeted_at        :datetime         not null
+#  tweet_id          :string(255)      not null
+#
 FactoryBot.define do
   factory :tweet do
     sequence(:oembed, 'HTML 1')

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id          :bigint           not null, primary key
+#  twitter_id  :string(255)      not null
+#  uuid        :string(255)      not null
+#  name        :string(255)      not null
+#  description :text(65535)
+#  privacy     :integer          default("published"), not null
+#  role        :integer          default("general"), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  screen_name :string(255)      not null
+#  avatar_url  :string(255)      default("https://abs.twimg.com/sticky/default_profile_images/default_profile.png"), not null
+#
 FactoryBot.define do
   factory :user do
     twitter_id { rand(10 ** 19).to_s }

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: authentications
+#
+#  id                  :bigint           not null, primary key
+#  user_id             :integer          not null
+#  provider            :string(255)      not null
+#  uid                 :string(255)      not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  access_token        :string(255)      default(""), not null
+#  access_token_secret :string(255)      default(""), not null
+#
 RSpec.describe Authentication, type: :model do
   describe 'associations' do
     it 'belongs_to :user' do

--- a/spec/models/registered_tag_spec.rb
+++ b/spec/models/registered_tag_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: registered_tags
+#
+#  id               :bigint           not null, primary key
+#  user_id          :bigint
+#  tag_id           :bigint
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  privacy          :integer          default("published"), not null
+#  remind_day       :integer          default(0), not null
+#  first_tweeted_at :datetime
+#
 RSpec.describe RegisteredTag, type: :model do
   describe 'associations' do
     it 'belongs_to :user' do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 RSpec.describe Tag, type: :model do
   describe 'associations' do
     it 'has_many :registered_tags, restrict_with_error' do

--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: tweets
+#
+#  id                :bigint           not null, primary key
+#  registered_tag_id :bigint
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  oembed            :text(65535)      not null
+#  tweeted_at        :datetime         not null
+#  tweet_id          :string(255)      not null
+#
 RSpec.describe Tweet, type: :model do
   describe 'associations' do
     it 'belongs_to registered_tag' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id          :bigint           not null, primary key
+#  twitter_id  :string(255)      not null
+#  uuid        :string(255)      not null
+#  name        :string(255)      not null
+#  description :text(65535)
+#  privacy     :integer          default("published"), not null
+#  role        :integer          default("general"), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  screen_name :string(255)      not null
+#  avatar_url  :string(255)      default("https://abs.twimg.com/sticky/default_profile_images/default_profile.png"), not null
+#
 RSpec.describe User, type: :model do
   describe 'associations' do
     it 'has_one :authentications, destroy' do

--- a/spec/requests/api/v1/tweets_spec.rb
+++ b/spec/requests/api/v1/tweets_spec.rb
@@ -119,11 +119,11 @@ RSpec.describe 'Tweets', type: :request do
     subject { post "/api/v1/registered_tags/#{registered_tag.id}/tweets", params: { tweet: { body: body } } }
     before { login_as(user) }
 
-    xcontext 'with valid', vcr: { cassette_name: 'twitter_api/update' } do
+    context 'with valid', vcr: { cassette_name: 'twitter_api/update' } do
       let(:body) { "#test 本文" }
       it do
         subject
-        expect(response.status).to eq 200
+        expect(response.status).to eq 201
       end
       it { expect{ subject }.to change { Tweet.count }.by(1) }
     end
@@ -134,9 +134,6 @@ RSpec.describe 'Tweets', type: :request do
         expect(response.status).to eq 422
       end
       it { expect{ subject }.not_to change { Tweet.count } }
-      it do
-
-      end
     end
   end
 end

--- a/spec/requests/api/v1/tweets_spec.rb
+++ b/spec/requests/api/v1/tweets_spec.rb
@@ -125,7 +125,12 @@ RSpec.describe 'Tweets', type: :request do
         subject
         expect(response.status).to eq 201
       end
-      it { expect{ subject }.to change { Tweet.count }.by(1) }
+      it 'ツイートを追加する' do
+        expect { subject }.to change { Tweet.count }.by(1)
+      end
+      it '最初のツイート日時に反映する' do
+        expect { subject }.to change { registered_tag.reload.first_tweeted_at }.from(nil)
+      end
     end
     context 'bodyがblankのとき' do
       let(:body) { '' }
@@ -133,7 +138,9 @@ RSpec.describe 'Tweets', type: :request do
         subject
         expect(response.status).to eq 422
       end
-      it { expect{ subject }.not_to change { Tweet.count } }
+      it 'ツイートを追加しない' do
+        expect { subject }.not_to change { Tweet.count }
+      end
     end
   end
 end

--- a/spec/services/job/add_tweets_spec.rb
+++ b/spec/services/job/add_tweets_spec.rb
@@ -4,6 +4,7 @@ describe Job::AddTweets do
   let(:tag) { create(:tag, name: 'ポートフォリオ進捗') }
   let(:add_tweets) { Job::AddTweets.new }
   describe '#call' do
+    subject { add_tweets.call }
     context 'ツイートを既に取得しているとき' do
       before 'タグ登録時にツイートを取得' do
         VCR.use_cassette('twitter_api/standard_search') do
@@ -13,29 +14,28 @@ describe Job::AddTweets do
       context '正常系 前日のツイートを取得したとき',
         vcr: { cassette_name: 'twitter_api/everyday_search/正常系 前日のツイートを取得したとき' } do
         it '取得したツイートを保存する' do
-          expect do
-            add_tweets.call
-          end.to change(Tweet, :count).by(3)
+          expect { subject }.to change(Tweet, :count).by(3)
         end
         it 'Rails.logger.infoでログを出力する' do
           expect(Rails.logger).to receive(:info).with('@aiandrox の #ポートフォリオ進捗 にツイートを追加')
-          add_tweets.call
+          subject
         end
       end
       context '既に前日のツイートを取得しているとき' do
         let(:add_tweets) { Job::AddTweets.new([registered_tag]) }
         it 'RegisteredTag#add_tweetsを実行しない' do
-          create(:tweet, :tweeted_yesterday, registered_tag: registered_tag)
-          registered_tag.fetch_tweets_data!
-          expect(registered_tag).not_to receive(:add_tweets)
-          add_tweets.call
+          tweet = create(:tweet, :tweeted_yesterday, registered_tag: registered_tag)
+          registered_tag.update!(first_tweeted_at: tweet.tweeted_at)
+
+          expect(registered_tag).not_to receive(:create_tweets)
+          subject
         end
       end
       context '前日のツイートがなかったとき',
         vcr: { cassette_name: 'twitter_api/everyday_search/前日のツイートがなかったとき' } do
         it 'Rails.logger.infoを実行しない' do
           expect(Rails.logger).not_to receive(:info)
-          add_tweets.call
+          subject
         end
       end
     end
@@ -47,7 +47,7 @@ describe Job::AddTweets do
       let(:add_tweets) { Job::AddTweets.new([registered_tag]) }
       it 'RegisteredTag#create_tweetsを実行する' do
         expect(registered_tag).to receive(:create_tweets)
-        add_tweets.call
+        subject
       end
     end
   end

--- a/spec/vcr_cassettes/twitter_api/update.yml
+++ b/spec/vcr_cassettes/twitter_api/update.yml
@@ -1,0 +1,162 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.twitter.com/1.1/statuses/update.json
+    body:
+      encoding: UTF-8
+      string: status=%23test+%E6%9C%AC%E6%96%87
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="c4f2cb73ce47e51c4eafdeb8d89ff270",
+        oauth_signature="7CrVlsjDDdyKG%2FGPKp434UBHMyI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1649480844", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 09 Apr 2022 05:07:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_m
+      Status:
+      - 200 OK
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Set-Cookie:
+      - guest_id=v1%3A164948084434864071; Max-Age=63072000; Expires=Mon, 08 Apr 2024
+        05:07:24 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_ads=v1%3A164948084434864071; Max-Age=63072000; Expires=Mon, 08 Apr
+        2024 05:07:24 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_marketing=v1%3A164948084434864071; Max-Age=63072000; Expires=Mon,
+        08 Apr 2024 05:07:24 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - lang=ja; Path=/
+      - personalization_id="v1_djqtF7SDWtJ0nf2xGXQPWw=="; Max-Age=63072000; Expires=Mon,
+        08 Apr 2024 05:07:24 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Content-Type:
+      - application/json;charset=utf-8
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Last-Modified:
+      - Sat, 09 Apr 2022 05:07:24 GMT
+      X-Transaction:
+      - 34d53236c87c424c
+      Content-Length:
+      - '3030'
+      X-Access-Level:
+      - read-write
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      Content-Disposition:
+      - attachment; filename=json.json
+      X-Content-Type-Options:
+      - nosniff
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Response-Time:
+      - '173'
+      X-Connection-Hash:
+      - 22a1c105de40962e4e279a7f805ae418ae881ee19e63f59215ae1d4b0cc15deb
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"created_at":"Sat Apr 09 05:07:24 +0000 2022","id":1512658413901078528,"id_str":"1512658413901078528","text":"#test
+        \u672c\u6587","truncated":false,"entities":{"hashtags":[{"text":"test","indices":[0,5]}],"symbols":[],"user_mentions":[],"urls":[]},"source":"\u003ca
+        href=\"https:\/\/hashlog.work\" rel=\"nofollow\"\u003eHashIog\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":1242379749650907137,"id_str":"1242379749650907137","name":"Hashlog
+        - \u3042\u306a\u305f\u306e\u5b66\u7fd2\u3092\u53ef\u8996\u5316\u3059\u308b\u30c4\u30a4\u30fc\u30c8\u8a18\u9332\u30b5\u30fc\u30d3\u30b9","screen_name":"Hash1og","location":"","description":"Hashlog\u306f\u3001\u30cf\u30c3\u30b7\u30e5\u30bf\u30b0\u3092\u767b\u9332\u3059\u308b\u3060\u3051\u3067\u3042\u306a\u305f\u306e\u7d99\u7d9a\u3092\u53ef\u8996\u5316\u3059\u308b
+        Twitter\u9023\u643a\u578b \u5b66\u7fd2\u8a18\u9332\u30b5\u30fc\u30d3\u30b9\u3067\u3059\u3002\n\u5b66\u7fd2\u306e\u632f\u308a\u8fd4\u308a\u3001\u9811\u5f35\u308a\u306e\u53ef\u8996\u5316\u3001\u30c4\u30a4\u30fc\u30c8\u306e\u30dd\u30fc\u30c8\u30d5\u30a9\u30ea\u30aa\u5316\u304c\u3067\u304d\u307e\u3059\u3002\n\u304a\u554f\u3044\u5408\u308f\u305b\u306f\u3053\u3061\u3089\u304b\u3089\u3069\u3046\u305e\u3002\u30ea\u30de\u30a4\u30f3\u30c0\u30fc\u7528\u306eBot\u3082\u517c\u306d\u3066\u3044\u307e\u3059\u3002\n\u7ba1\u7406\u8005\uff1a@aiandrox","url":"https:\/\/t.co\/G6yd9iUWcC","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/G6yd9iUWcC","expanded_url":"https:\/\/hashlog.work","display_url":"hashlog.work","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":78,"friends_count":87,"listed_count":0,"created_at":"Tue
+        Mar 24 09:16:34 +0000 2020","favourites_count":1526,"utc_offset":null,"time_zone":null,"geo_enabled":false,"verified":false,"statuses_count":751,"lang":null,"contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"F5F8FA","profile_background_image_url":null,"profile_background_image_url_https":null,"profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/1270548562221215744\/_lvOIniK_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/1270548562221215744\/_lvOIniK_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/1242379749650907137\/1591757543","profile_link_color":"1DA1F2","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":false,"default_profile":true,"default_profile_image":false,"following":false,"follow_request_sent":false,"notifications":false,"translator_type":"none","withheld_in_countries":[]},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":0,"favorite_count":0,"favorited":false,"retweeted":false,"lang":"ja"}'
+  recorded_at: Sat, 09 Apr 2022 05:07:24 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/oembed.json?hide_thread=true&id=1512658413901078528&lang=ja&omit_script=true
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/7.0.0
+      Authorization:
+      - OAuth oauth_consumer_key="<API KEY>", oauth_nonce="8509bf7bc35ee80c4e37460cb6b3d73a",
+        oauth_signature="O4306kdase1TzveYJnBPKFnJgy0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1649480844", oauth_token="<ACCESS TOKEN>", oauth_version="1.0"
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 09 Apr 2022 05:07:23 GMT
+      Server:
+      - tsa_m
+      Expires:
+      - Mon, 16 Mar 2122 05:07:24 GMT
+      Set-Cookie:
+      - guest_id=v1%3A164948084455971058; Max-Age=63072000; Expires=Mon, 08 Apr 2024
+        05:07:24 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_ads=v1%3A164948084455971058; Max-Age=63072000; Expires=Mon, 08 Apr
+        2024 05:07:24 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_marketing=v1%3A164948084455971058; Max-Age=63072000; Expires=Mon,
+        08 Apr 2024 05:07:24 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_CShz+6EGfM8xD0jD6b6B8A=="; Max-Age=63072000; Expires=Mon,
+        08 Apr 2024 05:07:24 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - must-revalidate, max-age=3153600000
+      Last-Modified:
+      - Sat, 09 Apr 2022 05:07:24 GMT
+      Content-Length:
+      - '852'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Reset:
+      - '1649481744'
+      Content-Disposition:
+      - attachment; filename=json.json
+      X-Content-Type-Options:
+      - nosniff
+      X-Rate-Limit-Remaining:
+      - '179'
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Response-Time:
+      - '113'
+      X-Connection-Hash:
+      - 792b04150fdbec2c2f3193d3c80249e8239c07b1d770bb7ab4c15e8125289a06
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"url":"https:\/\/twitter.com\/Hash1og\/status\/1512658413901078528","author_name":"Hashlog
+        - あなたの学習を可視化するツイート記録サービス","author_url":"https:\/\/twitter.com\/Hash1og","html":"\u003Cblockquote
+        class=\"twitter-tweet\" data-lang=\"ja\"\u003E\u003Cp lang=\"ja\" dir=\"ltr\"\u003E\u003Ca
+        href=\"https:\/\/twitter.com\/hashtag\/test?src=hash&amp;ref_src=twsrc%5Etfw\"\u003E#test\u003C\/a\u003E
+        本文\u003C\/p\u003E&mdash; Hashlog - あなたの学習を可視化するツイート記録サービス (@Hash1og) \u003Ca
+        href=\"https:\/\/twitter.com\/Hash1og\/status\/1512658413901078528?ref_src=twsrc%5Etfw\"\u003E2022年4月9日\u003C\/a\u003E\u003C\/blockquote\u003E\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}'
+  recorded_at: Sat, 09 Apr 2022 05:07:24 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## 概要
close #232


追加した機能
変更点
画像

## 使用gemや外部ツール


## 確認手順

1. Gem を追加したので `bundle install` を実行してください
2. カラムを追加したので `bundle exec rails db:migrate` を実行してください

## 想定される影響範囲

- データベース
- gem

## コメント

- レビュワーに見てほしい点
- 気づき

## 参考資料

公式リファレンスや参考記事へのリンク